### PR TITLE
Spells/Core: Telegraph additions (Circle, LongCone, Square, Rectangle)

### DIFF
--- a/Source/NexusForever.WorldServer/Game/Spell/Static/DamageShape.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/DamageShape.cs
@@ -2,7 +2,10 @@
 {
     public enum DamageShape
     {
-        Cone      = 4,
-        Rectangle = 7
+        Circle        = 0,
+        Quadrilateral = 2,
+        Cone          = 4,
+        Rectangle     = 7,
+        LongCone      = 8
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Spell/Telegraph.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Telegraph.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using NexusForever.Shared;
+using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
 using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Map.Search;
@@ -44,18 +45,81 @@ namespace NexusForever.WorldServer.Game.Spell
         {
             switch ((DamageShape)TelegraphDamage.DamageShapeEnum)
             {
+                case DamageShape.Circle:
+                    return Vector3.Distance(Position, position) < TelegraphDamage.Param00;
                 case DamageShape.Cone:
-                {
-                    float angleRadian = Position.GetAngle(position);
-                    angleRadian -= Rotation.X;
-                    angleRadian = angleRadian.NormaliseRadians();
+                case DamageShape.LongCone:
+                    {
+                        float angleRadian = Position.GetAngle(position);
+                        angleRadian -= Rotation.X;
+                        angleRadian = angleRadian.NormaliseRadians();
 
-                    float angleDegrees = MathF.Abs(angleRadian.ToDegrees());
-                    if (angleDegrees > TelegraphDamage.Param02 / 2f)
-                        return false;
+                        float angleDegrees = MathF.Abs(angleRadian.ToDegrees());
+                        if (angleDegrees > TelegraphDamage.Param02 / 2f)
+                            return false;
 
-                    return Vector3.Distance(Position, position) < TelegraphDamage.Param01;
-                }
+                        return Vector3.Distance(Position, position) < TelegraphDamage.Param01;
+                    }
+                case DamageShape.Quadrilateral:
+                    {
+                        float telegraphLength = TelegraphDamage.Param01;
+                        float telegraphHeight = TelegraphDamage.Param02;
+
+                        // TODO: If target is higher or lower than telegraph height, this should not hit. Confirm functionality.
+                        if (position.Y >= Position.Y + telegraphHeight || position.Y <= Position.Y - telegraphHeight)
+                            return false;
+
+                        float leftAngle = -Rotation.X + MathF.PI / 2;
+                        // TODO: Confirm whether it's necessary to add the model's hit box to the Z Offset (it probabbly is needed).
+                        Vector3 startingPosition = Position.GetPoint2D(-Rotation.X - MathF.PI / 2, TelegraphDamage.ZPositionOffset);
+                        startingPosition.Y += TelegraphDamage.YPositionOffset;
+
+                        Vector3 bottomLeft = startingPosition.GetPoint2D(leftAngle, (telegraphLength / 2f) + TelegraphDamage.XPositionOffset);
+                        Vector3 bottomRight = startingPosition.GetPoint2D(leftAngle + MathF.PI / 2, (telegraphLength / 2f) + TelegraphDamage.XPositionOffset);
+
+                        Vector3 topRight = bottomRight.GetPoint2D(-Rotation.X - MathF.PI / 4, telegraphLength);
+                        Vector3 topLeft = bottomLeft.GetPoint2D(-Rotation.X - MathF.PI / 4, telegraphLength);
+                        List<Vector3> points = new List<Vector3>
+                        {
+                            bottomLeft,
+                            bottomRight,
+                            topRight,
+                            topLeft
+                        };
+
+                        // TODO: Add appropriate check that takes Hit Box from Creature2Model TBL into account with check
+                        return IsPointInsidePolygon(new Vector2(position.X, position.Z), points.ToArray());
+                    }
+                case DamageShape.Rectangle:
+                    {
+                        float telegraphWidth = TelegraphDamage.Param00;
+                        float telegraphHeight = TelegraphDamage.Param01;
+                        float telegraphLength = TelegraphDamage.Param02;
+
+                        // TODO: If target is higher or lower than telegraph height, this should not hit. Confirm functionality.
+                        if (position.Y >= Position.Y + telegraphHeight || position.Y <= Position.Y - telegraphHeight)
+                            return false;
+
+                        float leftAngle = -Rotation.X + MathF.PI;
+                        // TODO: Confirm whether it's necessary to add the model's hit box to the Z Offset (it probabbly is needed).
+                        Vector3 startingPosition = Position.GetPoint2D(-Rotation.X - MathF.PI / 2, TelegraphDamage.ZPositionOffset);
+                        startingPosition.Y += TelegraphDamage.YPositionOffset;
+
+                        Vector3 bottomLeft = startingPosition.GetPoint2D(leftAngle, (telegraphWidth / 2f) + TelegraphDamage.XPositionOffset);
+                        Vector3 bottomRight = startingPosition.GetPoint2D(leftAngle + MathF.PI, (telegraphWidth / 2f) + TelegraphDamage.XPositionOffset);
+                        Vector3 topRight = bottomRight.GetPoint2D(-Rotation.X - MathF.PI / 2, telegraphLength);
+                        Vector3 topLeft = bottomLeft.GetPoint2D(-Rotation.X - MathF.PI / 2, telegraphLength);
+                        List<Vector3> points = new List<Vector3>
+                        {
+                            bottomLeft,
+                            bottomRight,
+                            topRight,
+                            topLeft
+                        };
+
+                        // TODO: Add appropriate check that takes Hit Box from Creature2Model TBL into account with check
+                        return IsPointInsidePolygon(new Vector2(position.X, position.Z), points.ToArray());
+                    }
                 default:
                     log.Warn($"Unhandled telegraph shape {(DamageShape)TelegraphDamage.DamageShapeEnum}.");
                     return false;
@@ -66,11 +130,40 @@ namespace NexusForever.WorldServer.Game.Spell
         {
             switch ((DamageShape)TelegraphDamage.DamageShapeEnum)
             {
+                case DamageShape.Circle:
+                    return TelegraphDamage.Param00;
                 case DamageShape.Cone:
+                case DamageShape.LongCone:
+                    return TelegraphDamage.Param01;
+                case DamageShape.Quadrilateral:
+                case DamageShape.Rectangle:
                     return TelegraphDamage.Param01;
                 default:
                     return 0f;
             }
+        }
+
+        /// <summary>
+        /// Returns a boolean whether a point sits in a horizontal plane of points
+        /// </summary>
+        /// <remarks>Based on code available in https://github.com/substack/point-in-polygon/ and the algorithm from https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html/</remarks>
+        private bool IsPointInsidePolygon(Vector2 point, Vector3[] polygon)
+        {
+            bool isInside = false;
+            for (int i = 0, j = polygon.Length- 1; i < polygon.Length; j = i++)
+            {
+                float xi = polygon[i].X;
+                float yi = polygon[i].Z;
+                float xj = polygon[j].X;
+                float yj = polygon[j].Z;
+
+                bool intersect = ((yi > point.Y) != (yj > point.Y))
+                    && (point.X < (xj - xi) * (point.Y - yi) / (yj - yi) + xi);
+
+                if (intersect) isInside = !isInside;
+            }
+
+            return isInside;
         }
     }
 }


### PR DESCRIPTION
I wouldn't say this was hacked together, but it's not far off that :) Thank you @Rawaho for the reference code that I blatantly plagiarised.

I also took a quick look at the offset positions, they don't seem overly difficult to figure out, but I believe that the offset will need to happen at Telegraph instantiation rather than at the damage check. For now, I have it calculating "forward" offset in the telegraph check.