### PR TITLE
Spells/Core: Spell Casting MEGAUPDATE

### DIFF
--- a/Source/NexusForever.Shared/GameTable/GameTableManager.cs
+++ b/Source/NexusForever.Shared/GameTable/GameTableManager.cs
@@ -536,7 +536,9 @@ namespace NexusForever.Shared.GameTable
         [GameData]
         public GameTable<Spell4TelegraphEntry> Spell4Telegraph { get; private set; }
 
+        [GameData]
         public GameTable<Spell4ThresholdsEntry> Spell4Thresholds { get; private set; }
+
         public GameTable<Spell4TierRequirementsEntry> Spell4TierRequirements { get; private set; }
 
         [GameData]
@@ -552,6 +554,8 @@ namespace NexusForever.Shared.GameTable
 
         [GameData]
         public GameTable<SpellLevelEntry> SpellLevel { get; private set; }
+
+        [GameData]
         public GameTable<SpellPhaseEntry> SpellPhase { get; private set; }
 
         [GameData]

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -242,11 +242,12 @@ namespace NexusForever.Shared.Network.Message
         ClientSpellStopCast             = 0x0801,
         ClientCancelEffect              = 0x0802,
         ServerCooldown                  = 0x0804,
+        Server0810                      = 0x0810,
         Server0811                      = 0x0811, // spell related: broadcast parts of 0x07FF?
         ServerSpellBuffRemove           = 0x0813,
-        Server0814                      = 0x0814, // spell related
-        Server0816                      = 0x0816, // spell related: broadcast parts of 0x07FF?
-        Server0817                      = 0x0817, // spell related
+        ServerSpellThresholdClear       = 0x0814,
+        ServerSpellThresholdStart       = 0x0816,
+        ServerSpellThresholdUpdate      = 0x0817, 
         Server0818                      = 0x0818,
         ClientStorefrontPurchaseAccount = 0x0828,
         ClientStorefrontPurchaseCharacter = 0x082A,

--- a/Source/NexusForever.WorldServer/Game/Spell/CastMethodHandler.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/CastMethodHandler.cs
@@ -1,0 +1,106 @@
+﻿using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.Entity;
+using NexusForever.WorldServer.Game.Spell.Event;
+using NexusForever.WorldServer.Game.Spell.Static;
+using NexusForever.WorldServer.Network.Message.Model;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Spell
+{
+    public delegate void CastMethodDelegate(Spell spell);
+
+    public partial class Spell
+    {
+        [CastMethodHandler(CastMethod.Normal)]
+        private void NormalHandler()
+        {
+            events.EnqueueEvent(new SpellEvent(parameters.SpellInfo.Entry.CastTime / 1000d, Execute)); // enqueue spell to be executed after cast time
+        }
+
+        [CastMethodHandler(CastMethod.Multiphase)]
+        private void MultiphaseHandler()
+        {
+            status = SpellStatus.Executing;
+            log.Trace($"Spell {parameters.SpellInfo.Entry.Id} has started executing.");
+
+            uint spellDelay = 0;
+            for(int i = 0; i < parameters.SpellInfo.Phases.Count; i++)
+            {
+                int index = i;
+                SpellPhaseEntry spellPhase = parameters.SpellInfo.Phases[i];
+                spellDelay += spellPhase.PhaseDelay;
+                events.EnqueueEvent(new SpellEvent(spellDelay / 1000d, () =>
+                {
+                    currentPhase = (byte)spellPhase.OrderIndex;
+                    Execute();
+
+                    targets.ForEach(t => t.Effects.Clear());
+                }));
+            }
+        }
+
+        [CastMethodHandler(CastMethod.Channeled)]
+        [CastMethodHandler(CastMethod.ChanneledField)]
+        private void ChanneledHandler()
+        {
+            events.EnqueueEvent(new SpellEvent(parameters.SpellInfo.Entry.ChannelInitialDelay / 1000d, () =>
+            {
+                Execute();
+
+                targets.ForEach(t => t.Effects.Clear());
+            })); // Execute after initial delay
+            events.EnqueueEvent(new SpellEvent(parameters.SpellInfo.Entry.ChannelMaxTime / 1000d, Finish)); // End Spell Cast
+
+            uint numberOfPulses = (uint)MathF.Floor(parameters.SpellInfo.Entry.ChannelMaxTime / parameters.SpellInfo.Entry.ChannelPulseTime); // Calculate number of "ticks" in this spell cast
+
+            // Add ticks at each pulse
+            for (int i = 1; i <= numberOfPulses; i++)
+                events.EnqueueEvent(new SpellEvent((parameters.SpellInfo.Entry.ChannelInitialDelay + (parameters.SpellInfo.Entry.ChannelPulseTime * i)) / 1000d, () =>
+                {
+                    Execute();
+
+                    targets.ForEach(t => t.Effects.Clear());
+                }));
+        }
+
+        [CastMethodHandler(CastMethod.ChargeRelease)]
+        private void ChargeReleaseHandler()
+        {
+            if (parameters.ParentSpellInfo == null)
+            {
+                totalThresholdTimer = (uint)(parameters.SpellInfo.Entry.ThresholdTime / 1000d);
+
+                // Keep track of cast time increments as we create timers to adjust thresholdValue
+                uint nextCastTime = 0;
+                
+                // Create timers for each thresholdEntry's timer increment
+                foreach (Spell4ThresholdsEntry thresholdsEntry in parameters.SpellInfo.Thresholds)
+                {
+                    nextCastTime += thresholdsEntry.ThresholdDuration;
+
+                    if (thresholdsEntry.OrderIndex == 0)
+                        continue;
+
+                    events.EnqueueEvent(new SpellEvent(parameters.SpellInfo.Entry.CastTime / 1000d + nextCastTime / 1000d, () =>
+                    {
+                        thresholdValue = thresholdsEntry.OrderIndex;
+                        SendThresholdUpdate();
+                    }));
+                }
+            }
+
+            events.EnqueueEvent(new SpellEvent(parameters.SpellInfo.Entry.CastTime / 1000d, Execute)); // enqueue spell to be executed after cast time
+        }
+
+        [CastMethodHandler(CastMethod.RapidTap)]
+        private void RapidTapHandler()
+        {
+            if (parameters.ParentSpellInfo == null)
+                events.EnqueueEvent(new SpellEvent(parameters.SpellInfo.Entry.CastTime / 1000d + parameters.SpellInfo.Entry.ThresholdTime / 1000d, Finish)); // enqueue spell to be executed after cast time
+
+            events.EnqueueEvent(new SpellEvent(parameters.SpellInfo.Entry.CastTime / 1000d, Execute)); // enqueue spell to be executed after cast time
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Spell/CastMethodHandlerAttribute.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/CastMethodHandlerAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using NexusForever.WorldServer.Game.Spell.Static;
+
+namespace NexusForever.WorldServer.Game.Spell
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class CastMethodHandlerAttribute : Attribute
+    {
+        public CastMethod CastMethod { get; }
+
+        public CastMethodHandlerAttribute(CastMethod castMethod)
+        {
+            CastMethod = castMethod;
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Spell/CharacterSpell.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/CharacterSpell.cs
@@ -133,6 +133,15 @@ namespace NexusForever.WorldServer.Game.Spell
         /// </summary>
         public void Cast()
         {
+            if (Owner.HasSpell(BaseInfo.GetSpellInfo(Tier).Entry.Id, out Spell spell))
+            {
+                if ((spell.CastMethod == CastMethod.RapidTap || spell.CastMethod == CastMethod.ChargeRelease) && !spell.IsFinished)
+                {
+                    spell.Cast();
+                    return;
+                }
+            }
+
             CastSpell();
         }
 
@@ -144,8 +153,17 @@ namespace NexusForever.WorldServer.Game.Spell
             // TODO: Handle continuous casting of spell for Player if button remains depressed
 
             // If the player depresses button after the spell had exceeded its threshold, don't try and recast the spell until button is pressed down again.
-            if (!buttonPressed)
+            if (!buttonPressed && (CastMethod)BaseInfo.Entry.CastMethod != CastMethod.ChargeRelease)
                 return;
+
+            if (Owner.HasSpell(BaseInfo.GetSpellInfo(Tier).Entry.Id, out Spell spell))
+            {
+                if ((spell.CastMethod == CastMethod.RapidTap || spell.CastMethod == CastMethod.ChargeRelease) && !spell.IsFinished)
+                {
+                    spell.Cast();
+                    return;
+                }
+            }
 
             CastSpell();
         }

--- a/Source/NexusForever.WorldServer/Game/Spell/SpellInfo.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/SpellInfo.cs
@@ -23,6 +23,8 @@ namespace NexusForever.WorldServer.Game.Spell
 
         public List<TelegraphDamageEntry> Telegraphs { get; }
         public List<Spell4EffectsEntry> Effects { get; }
+        public List<Spell4ThresholdsEntry> Thresholds { get; }
+        public List<SpellPhaseEntry> Phases { get; }
 
         public SpellInfo(SpellBaseInfo spellBaseBaseInfo, Spell4Entry spell4Entry)
         {
@@ -42,6 +44,8 @@ namespace NexusForever.WorldServer.Game.Spell
 
             Telegraphs = GlobalSpellManager.Instance.GetTelegraphDamageEntries(spell4Entry.Id).ToList();
             Effects = GlobalSpellManager.Instance.GetSpell4EffectEntries(spell4Entry.Id).ToList();
+            Thresholds = GlobalSpellManager.Instance.GetSpell4ThresholdEntries(spell4Entry.Id).ToList();
+            Phases = GlobalSpellManager.Instance.GetSpellPhaseEntries(spell4Entry.Id).ToList();
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Spell/SpellParameters.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/SpellParameters.cs
@@ -12,5 +12,7 @@ namespace NexusForever.WorldServer.Game.Spell
         public uint PrimaryTargetId { get; set; }
         public Position Position { get; set; }
         public ushort TaxiNode { get; set; }
+        public uint ThresholdValue { get; set; }
+        public bool IsProxy { get; set; }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/CastMethod.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/CastMethod.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Spell.Static
+{
+    public enum CastMethod
+    {
+        Normal                = 0x0000,
+        Channeled             = 0x0001,
+        PressHold             = 0x0002,
+        ChanneledField        = 0x0003,
+        UNUSED04              = 0x0004,
+        ClientSideInteraction = 0x0005,
+        RapidTap              = 0x0006,
+        ChargeRelease         = 0x0007,
+        Multiphase            = 0x0008,
+        Transactional         = 0x0009,
+        Aura                  = 0x000A
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Spell/Static/SpellStatus.cs
+++ b/Source/NexusForever.WorldServer/Game/Spell/Static/SpellStatus.cs
@@ -5,6 +5,8 @@
         Initiating,
         Casting,
         Executing,
-        Finished
+        Finished,
+        Waiting,
+        Failed
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientCastSpell.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientCastSpell.cs
@@ -6,14 +6,14 @@ namespace NexusForever.WorldServer.Network.Message.Model
     [Message(GameMessageOpcode.ClientCastSpell)]
     public class ClientCastSpell : IReadable
     {
-        public uint ClientUniqueId { get; private set; } // first value of 0x7FD response, probably global increment
+        public uint ClientUniqueId { get; private set; }
         public ushort BagIndex { get; private set; }
         public uint CasterId { get; private set; }
         public bool ButtonPressed { get; private set; }
 
         public void Read(GamePacketReader reader)
         {
-            ClientUniqueId  = reader.ReadUInt();
+            ClientUniqueId = reader.ReadUInt();
             BagIndex  = reader.ReadUShort();
             CasterId  = reader.ReadUInt();
             ButtonPressed  = reader.ReadBit();

--- a/Source/NexusForever.WorldServer/Network/Message/Model/Server0810.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/Server0810.cs
@@ -1,0 +1,32 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using System.Collections.Generic;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.Server0810)]
+    public class Server0810 : IWritable
+    {
+        public class SpellTarget : IWritable
+        {
+            public uint ServerUniqueId { get; set; }
+            public uint TargetId { get; set; }
+            public uint InstanceCount { get; set; }
+
+            public void Write(GamePacketWriter writer)
+            {
+                writer.Write(ServerUniqueId);
+                writer.Write(TargetId);
+                writer.Write(InstanceCount);
+            }
+        }
+
+        public List<SpellTarget> spellTargets { get; set; } = new List<SpellTarget>();
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(spellTargets.Count, 32u);
+            spellTargets.ForEach(i => i.Write(writer));
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/Server0811.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/Server0811.cs
@@ -8,13 +8,13 @@ namespace NexusForever.WorldServer.Network.Message.Model
     public class Server0811 : IWritable
     {
         public uint CastingId { get; set; }
-        public List<uint> CasterId { get; set; } = new List<uint>();
+        public List<uint> SpellTargets { get; set; } = new List<uint>();
 
         public void Write(GamePacketWriter writer)
         {
             writer.Write(CastingId);
-            writer.Write(CasterId.Count, 32u);
-            CasterId.ForEach(c => writer.Write(c));
+            writer.Write(SpellTargets.Count, 32u);
+            SpellTargets.ForEach(c => writer.Write(c));
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellGo.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellGo.cs
@@ -37,7 +37,7 @@ namespace NexusForever.WorldServer.Network.Message.Model
         public List<TelegraphPosition> TelegraphPositionData { get; set; } = new List<TelegraphPosition>();
         public List<MissileInfo> MissileInfoData { get; set; } = new List<MissileInfo>();
 
-        public sbyte Phase { get; set; }
+        public byte Phase { get; set; }
 
         public void Write(GamePacketWriter writer)
         {

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellStart.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellStart.cs
@@ -2,50 +2,13 @@ using System.Collections.Generic;
 using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
 using NexusForever.WorldServer.Game.Entity;
+using NexusForever.WorldServer.Network.Message.Model.Shared;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {
     [Message(GameMessageOpcode.ServerSpellStart)]
     public class ServerSpellStart : IWritable
     {
-        public class InitialPosition : IWritable
-        {   
-            public uint   CasterId { get; set; }
-            public byte   Unknown4 { get; set; }
-            public Position Position { get; set; } = new Position();
-            public float  Yaw { get; set; }
-            public uint   Unknown21 { get; set; }
-
-            public void Write(GamePacketWriter writer)
-            {
-                writer.Write(CasterId);
-                writer.Write(Unknown4);
-                Position.Write(writer);
-                writer.Write(Yaw);
-                writer.Write(Unknown21);
-            }
-        }
-
-        public class TelegraphPosition : IWritable
-        {   
-            public ushort Unknown0 { get; set; }
-            public uint   CasterId { get; set; }
-            public byte   Unknown6 { get; set; }
-            public Position Position { get; set; } = new Position();
-            public float  Yaw { get; set; }
-            public uint   Unknown23 { get; set; }
-
-            public void Write(GamePacketWriter writer)
-            {
-                writer.Write(Unknown0);
-                writer.Write(CasterId);
-                writer.Write(Unknown6);
-                Position.Write(writer);
-                writer.Write(Yaw);
-                writer.Write(Unknown23);
-            }
-        }
-
         public uint CastingId { get; set; }
         public uint Spell4Id { get; set; }
         public uint RootSpell4Id { get; set; }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellThresholdClear.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellThresholdClear.cs
@@ -3,8 +3,8 @@ using NexusForever.Shared.Network.Message;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {
-    [Message(GameMessageOpcode.Server0814)]
-    public class Server0814 : IWritable
+    [Message(GameMessageOpcode.ServerSpellThresholdClear)]
+    public class ServerSpellThresholdClear : IWritable
     {
         public uint Spell4Id { get; set; }
         public bool Unknown0 { get; set; }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellThresholdStart.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellThresholdStart.cs
@@ -3,8 +3,8 @@ using NexusForever.Shared.Network.Message;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {
-    [Message(GameMessageOpcode.Server0816)]
-    public class Server0816 : IWritable
+    [Message(GameMessageOpcode.ServerSpellThresholdStart)]
+    public class ServerSpellThresholdStart : IWritable
     {
         public uint Spell4Id { get; set; }
         public uint RootSpell4Id { get; set; }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellThresholdUpdate.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerSpellThresholdUpdate.cs
@@ -3,16 +3,16 @@ using NexusForever.Shared.Network.Message;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {
-    [Message(GameMessageOpcode.Server0817)]
-    public class Server0817 : IWritable
+    [Message(GameMessageOpcode.ServerSpellThresholdUpdate)]
+    public class ServerSpellThresholdUpdate : IWritable
     {
         public uint Spell4Id { get; set; }
-        public byte Unknown0 { get; set; }
+        public byte Value { get; set; }
 
         public void Write(GamePacketWriter writer)
         {
             writer.Write(Spell4Id, 18u);
-            writer.Write(Unknown0);
+            writer.Write(Value);
         }
     }
 }


### PR DESCRIPTION
After some time spent working on spell casting improvements, this is now at a place where it really needs a review.
I've made heavy use of the spell event system to provide correctly timed spell casting. This may not be the most efficient resource usage, so a review on this part in particular is requested. A lot of time was spent researching the spell casting packets and how they instruct the client what to do. From what I can tell, our spell packets trigger and mimic retail's, now (minus unknown packets).

- Cast methods added
   - Multiphase (Used very frequently by NPC spells)
   - Rapid Tap
   - Charge and Release
- Spell finishing
   - This update includes the functionality to end spell casts at the appropriate duration.
- Buff Timers
   - Added buff timers in line with how they worked in spell packets from retail.
- Proxy Spell fixes
   - Proxy spells that ticked at a period interval were presented differently in the tables. The proxy handler has been corrected to handle this appropriately.
- Threshold Casting
   - These are, essentially, steps to a spell cast that require 2 or more button presses. This is used as part of Rapid Tap and Charge and Release casting.
- Phased Casts
   - These phases indicate trigger points during a single spell cast. Spells like Shred which hit 3 times during a single cast make use of spell phases. This is used as part of Multiphase casting.
- ~~`UnlockedSpell` handler~~
   - ~~All LAS spell casts now take place "through" the `UnlockedSpell` instance associated with the button. This enables the server to better keep context of an existing spell, and opens up possibilities for improvements later (like tracking Spell Cooldown via the `UnlockedSpell` instance so we don't use server resources on re-checking every time an ability cast is requested)~~
   - Replaced by `CharacterSpell` that got added as part of another PR.