### PR TITLE
Account/Inventory: Inventory management, item binding

### DIFF
--- a/Source/NexusForever.Database.Auth/AuthContext.cs
+++ b/Source/NexusForever.Database.Auth/AuthContext.cs
@@ -11,6 +11,8 @@ namespace NexusForever.Database.Auth
         public DbSet<AccountCurrencyModel> AccountCurrency { get; set; }
         public DbSet<AccountEntitlementModel> AccountEntitlement { get; set; }
         public DbSet<AccountGenericUnlockModel> AccountGenericUnlock { get; set; }
+        public DbSet<AccountItemModel> AccountItem { get; set; }
+        public DbSet<AccountItemCooldownModel> AccountItemCooldown { get; set; }
         public DbSet<AccountKeybindingModel> AccountKeybinding { get; set; }
         public DbSet<ServerModel> Server { get; set; }
         public DbSet<ServerMessageModel> ServerMessage { get; set; }
@@ -194,6 +196,67 @@ namespace NexusForever.Database.Auth
                     .WithMany(p => p.AccountGenericUnlock)
                     .HasForeignKey(d => d.Id)
                     .HasConstraintName("FK__account_generic_unlock_id__account_id");
+            });
+
+            modelBuilder.Entity<AccountItemModel>(entity =>
+            {
+                entity.HasKey(e => new { e.Id, e.AccountId })
+                    .HasName("PRIMARY");
+
+                entity.ToTable("account_item");
+
+                entity.Property(e => e.Id)
+                    .HasColumnName("entry")
+                    .HasColumnType("bigint(20) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.AccountId)
+                    .HasColumnName("accountId")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.ItemId)
+                    .HasColumnName("itemId")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.HasOne(d => d.Account)
+                    .WithMany(p => p.AccountItem)
+                    .HasForeignKey(d => d.AccountId)
+                    .HasConstraintName("FK__account_item_accountId__account_id");
+            });
+
+            modelBuilder.Entity<AccountItemCooldownModel>(entity =>
+            {
+                entity.HasKey(e => new { e.Id, e.CooldownGroupId })
+                    .HasName("PRIMARY");
+
+                entity.ToTable("account_item_cooldown");
+
+                entity.Property(e => e.Id)
+                    .HasColumnName("id")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.CooldownGroupId)
+                    .HasColumnName("cooldownGroupId")
+                    .HasColumnType("int(10) unsigned")
+                    .ValueGeneratedNever();
+
+                entity.Property(e => e.Timestamp)
+                    .HasColumnName("timestamp")
+                    .HasColumnType("datetime")
+                    .HasDefaultValueSql("current_timestamp()");
+
+                entity.Property(e => e.Duration)
+                    .HasColumnName("duration")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.HasOne(d => d.Account)
+                    .WithMany(p => p.AccountItemCooldown)
+                    .HasForeignKey(d => d.Id)
+                    .HasConstraintName("FK__account_item_cooldown_id__account_id");
             });
 
             modelBuilder.Entity<AccountKeybindingModel>(entity =>

--- a/Source/NexusForever.Database.Auth/AuthDatabase.cs
+++ b/Source/NexusForever.Database.Auth/AuthDatabase.cs
@@ -71,9 +71,11 @@ namespace NexusForever.Database.Auth
             return await context.Account
                 .Include(a => a.AccountCostumeUnlock)
                 .Include(a => a.AccountCurrency)
-                .Include(a => a.AccountGenericUnlock)
-                .Include(a => a.AccountKeybinding)
                 .Include(a => a.AccountEntitlement)
+                .Include(a => a.AccountGenericUnlock)
+                .Include(a => a.AccountItem)
+                .Include(a => a.AccountItemCooldown)
+                .Include(a => a.AccountKeybinding)
                 .SingleOrDefaultAsync(a => a.Email == email && a.SessionKey == sessionKey);
         }
 
@@ -147,6 +149,16 @@ namespace NexusForever.Database.Auth
             return context.ServerMessage
                 .AsNoTracking()
                 .ToImmutableList();
+        }
+
+        public ulong GetNextAccountItemId()
+        {
+            using var context = new AuthContext(config);
+
+            return context.AccountItem
+                .GroupBy(i => 1)
+                .Select(g => g.Max(s => s.Id))
+                .ToList()[0];
         }
     }
 }

--- a/Source/NexusForever.Database.Auth/Migrations/20200426162617_AccountItems.Designer.cs
+++ b/Source/NexusForever.Database.Auth/Migrations/20200426162617_AccountItems.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NexusForever.Database.Auth;
 
 namespace NexusForever.Database.Auth.Migrations
 {
     [DbContext(typeof(AuthContext))]
-    partial class AuthContextModelSnapshot : ModelSnapshot
+    [Migration("20200426162617_AccountItems")]
+    partial class AccountItems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Source/NexusForever.Database.Auth/Migrations/20200426162617_AccountItems.cs
+++ b/Source/NexusForever.Database.Auth/Migrations/20200426162617_AccountItems.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace NexusForever.Database.Auth.Migrations
+{
+    public partial class AccountItems : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "account_item",
+                columns: table => new
+                {
+                    entry = table.Column<ulong>(type: "bigint(20) unsigned", nullable: false, defaultValue: 0ul),
+                    accountId = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    itemId = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => new { x.entry, x.accountId });
+                    table.ForeignKey(
+                        name: "FK__account_item_accountId__account_id",
+                        column: x => x.accountId,
+                        principalTable: "account",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "account_item_cooldown",
+                columns: table => new
+                {
+                    id = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    cooldownGroupId = table.Column<uint>(type: "int(10) unsigned", nullable: false),
+                    timestamp = table.Column<DateTime>(type: "datetime", nullable: true, defaultValueSql: "current_timestamp()"),
+                    duration = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => new { x.id, x.cooldownGroupId });
+                    table.ForeignKey(
+                        name: "FK__account_item_cooldown_id__account_id",
+                        column: x => x.id,
+                        principalTable: "account",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_account_item_accountId",
+                table: "account_item",
+                column: "accountId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "account_item");
+
+            migrationBuilder.DropTable(
+                name: "account_item_cooldown");
+        }
+    }
+}

--- a/Source/NexusForever.Database.Auth/Model/AccountItemCooldownModel.cs
+++ b/Source/NexusForever.Database.Auth/Model/AccountItemCooldownModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace NexusForever.Database.Auth.Model
+{
+    public class AccountItemCooldownModel
+    {
+        public uint Id { get; set; }
+        public uint CooldownGroupId { get; set; }
+        public DateTime? Timestamp { get; set; }
+        public uint Duration { get; set; }
+
+        public AccountModel Account { get; set; }
+    }
+}

--- a/Source/NexusForever.Database.Auth/Model/AccountItemModel.cs
+++ b/Source/NexusForever.Database.Auth/Model/AccountItemModel.cs
@@ -1,0 +1,11 @@
+﻿namespace NexusForever.Database.Auth.Model
+{
+    public class AccountItemModel
+    {
+        public ulong Id { get; set; }
+        public uint AccountId { get; set; }
+        public uint ItemId { get; set; }
+
+        public AccountModel Account { get; set; }
+    }
+}

--- a/Source/NexusForever.Database.Auth/Model/AccountModel.cs
+++ b/Source/NexusForever.Database.Auth/Model/AccountModel.cs
@@ -17,6 +17,8 @@ namespace NexusForever.Database.Auth.Model
         public ICollection<AccountCurrencyModel> AccountCurrency { get; set; } = new HashSet<AccountCurrencyModel>();
         public ICollection<AccountEntitlementModel> AccountEntitlement { get; set; } = new HashSet<AccountEntitlementModel>();
         public ICollection<AccountGenericUnlockModel> AccountGenericUnlock { get; set; } = new HashSet<AccountGenericUnlockModel>();
+        public ICollection<AccountItemModel> AccountItem { get; set; } = new HashSet<AccountItemModel>();
+        public ICollection<AccountItemCooldownModel> AccountItemCooldown { get; set; } = new HashSet<AccountItemCooldownModel>();
         public ICollection<AccountKeybindingModel> AccountKeybinding { get; set; } = new HashSet<AccountKeybindingModel>();
     }
 }

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -246,6 +246,7 @@ namespace NexusForever.Shared.Network.Message
         ClientStorefrontPurchaseCharacter = 0x082A,
         ClientStorefrontRequestCatalog  = 0x082D,
         ClientSummonVanityPet           = 0x082F,
+        ClientAccountItemBind           = 0x0839,
         ServerTimeOfDay                 = 0x0845,
         Server0854                      = 0x0854, // crafting schematic
         Server0856                      = 0x0856, // tradeskills
@@ -279,10 +280,12 @@ namespace NexusForever.Shared.Network.Message
         ServerAccountCurrencyGrant      = 0x0967,
         ServerAccountEntitlements       = 0x0968,
         ServerAccountItems              = 0x096D,
+        ServerAccountOperationResult    = 0x0970,
         ServerAccountEntitlement        = 0x0973,
         ServerAccountItemCooldownSet    = 0x0974,
         ServerAccountItemAdd            = 0x0975,
         ServerAccountItemsPending       = 0x0979,
+        ServerAccountItemDelete         = 0x097C,
         ServerGenericUnlockList         = 0x0981,
         ServerGenericUnlock             = 0x0982,
         ServerGenericUnlockResult       = 0x0985,

--- a/Source/NexusForever.WorldServer/Command/Handler/AccountCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/AccountCommandHandler.cs
@@ -101,5 +101,33 @@ namespace NexusForever.WorldServer.Command.Handler
 
             return Task.CompletedTask;
         }
+
+        [SubCommandHandler("itemadd", "Add an Account Item to the Account Inventory")]
+        public Task HandleAccountItemAdd(CommandContext context, string command, string[] parameters)
+        {
+            if (parameters.Length == 0)
+            {
+                SendHelpAsync(context);
+                return Task.CompletedTask;
+            }
+
+            uint itemId = 0;
+            if (!uint.TryParse(parameters[0], out itemId))
+            {
+                context.SendErrorAsync($"Could not parse Item ID. Please make sure you've entered it correctly.");
+                return Task.CompletedTask;
+            }
+
+            AccountItemEntry accountItem = GameTableManager.Instance.AccountItem.GetEntry(itemId);
+            if (accountItem == null)
+            {
+                context.SendErrorAsync($"Could not find Account Item with ID {itemId}. Please try again with a valid ID.");
+                return Task.CompletedTask;
+            }
+
+            context.Session.AccountInventory.ItemCreate(accountItem);
+
+            return Task.CompletedTask;
+        }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Account/AccountInventory.cs
+++ b/Source/NexusForever.WorldServer/Game/Account/AccountInventory.cs
@@ -1,0 +1,248 @@
+﻿using NexusForever.Database.Auth;
+using NexusForever.Database.Auth.Model;
+using NexusForever.Shared.GameTable;
+using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.Account.Static;
+using NexusForever.WorldServer.Network;
+using NexusForever.WorldServer.Network.Message.Model;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NexusForever.WorldServer.Game.Prerequisite;
+using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Game.Entity;
+
+namespace NexusForever.WorldServer.Game.Account
+{
+    public class AccountInventory : ISaveAuth, IEnumerable<AccountItem>
+    {
+        private readonly WorldSession session;
+
+        private readonly Dictionary</* id */ ulong, AccountItem> items = new Dictionary<ulong, AccountItem>();
+        private readonly Dictionary</* id */ uint, AccountItemCooldown> cooldowns = new Dictionary<uint, AccountItemCooldown>();
+        private readonly HashSet<AccountItem> deletedItems = new HashSet<AccountItem>();
+
+        /// <summary>
+        /// Create a new <see cref="AccountInventory"/> for this <see cref="WorldSession"/> with a given <see cref="AccountModel"/>.
+        /// </summary>
+        public AccountInventory(WorldSession session, AccountModel model)
+        {
+            this.session = session;
+
+            foreach (AccountItemModel accountItemModel in model.AccountItem)
+                items.TryAdd(accountItemModel.Id, new AccountItem(accountItemModel));
+
+            foreach (AccountItemCooldownModel cooldown in model.AccountItemCooldown)
+                cooldowns.TryAdd(cooldown.CooldownGroupId, new AccountItemCooldown(cooldown));
+
+            if (cooldowns.Keys.Count == GameTableManager.Instance.AccountItemCooldownGroup.Entries.Length) 
+                return;
+
+            foreach (AccountItemCooldownGroupEntry cooldownEntry in GameTableManager.Instance.AccountItemCooldownGroup.Entries)
+                cooldowns.TryAdd(cooldownEntry.Id, new AccountItemCooldown(session, cooldownEntry.Id));
+        }
+
+        /// <summary>
+        /// Save all <see cref="AccountItem"/> changes to the database.
+        /// </summary>
+        public void Save(AuthContext context)
+        {
+            foreach (AccountItem deletedItem in deletedItems)
+                deletedItem.Save(context);
+
+            deletedItems.Clear();
+
+            foreach (AccountItem item in items.Values)
+                item.Save(context);
+
+            foreach (AccountItemCooldown cooldown in cooldowns.Values)
+                cooldown.Save(context);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="AccountItem"/> from an <see cref="AccountItemEntry"/>.
+        /// </summary>
+        public void ItemCreate(AccountItemEntry entry)
+        {
+            if (entry == null)
+                throw new ArgumentNullException(nameof(entry));
+
+            AccountItem item = new AccountItem(session, entry);
+            items.TryAdd(item.Id, item);
+
+            SendAccountItemList();
+        }
+
+        /// <summary>
+        /// Delete an <see cref="AccountItem"/> given an ID.
+        /// </summary>
+        public void ItemDelete(ulong id)
+        {
+            if (!GetItem(id, out AccountItem item))
+                throw new ArgumentOutOfRangeException(nameof(id));
+
+            item.EnqueueDelete();
+            deletedItems.Add(item);
+            items.Remove(id);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="AccountItem"/> from this <see cref="AccountInventory"/>, if it exists.
+        /// </summary>
+        public bool GetItem(ulong id, out AccountItem item)
+        {
+            if (!items.TryGetValue(id, out item))
+                item = null;
+
+            return item != null;
+        }
+
+        /// <summary>
+        /// Binds the <see cref="AccountItem"/> that matches the given ID to the Character. This should only be called by a Client handler.
+        /// </summary>
+        public void BindItem(ulong id)
+        {
+            if (id == 0)
+                throw new ArgumentOutOfRangeException(nameof(id));
+
+            if (!GetItem(id, out AccountItem item))
+                throw new InvalidOperationException($"AccountItem ID {id} not found.");
+
+            // TODO: Add checks for things like In Combat, Is Dead, etc.
+
+            if (item.Entry.EntitlementId != 0u)
+            {
+                AccountEntitlement entitlement =
+                    session.EntitlementManager.GetAccountEntitlement((EntitlementType) item.Entry.EntitlementId);
+                if (entitlement != null)
+                    if (entitlement.Amount + item.Entry.EntitlementCount > entitlement.Entry.MaxCount)
+                    {
+                        SendAccountOperationResult(AccountOperation.TakeItem, AccountOperationResult.MaxEntitlementCount);
+                        return;
+                    }
+            }
+
+            if (item.Entry.PrerequisiteId != 0u &&
+                !PrerequisiteManager.Instance.Meets(session.Player, item.Entry.PrerequisiteId))
+            {
+                SendAccountOperationResult(AccountOperation.TakeItem, AccountOperationResult.Prereq);
+                return;
+            }
+
+            // Handle Set Cooldown
+            if (item.Entry.AccountItemCooldownGroupId != 0u)
+            {
+                if (IsOnCooldown(item.Entry.AccountItemCooldownGroupId))
+                {
+                    SendAccountOperationResult(AccountOperation.TakeItem, AccountOperationResult.Cooldown);
+                    return;
+                }
+
+                SetCooldown(item.Entry.AccountItemCooldownGroupId);
+            }
+
+            // Send any Item packets
+            if ((item.Flags & AccountItemFlag.MultiClaim) == 0)
+            {
+                SendAccountItemDelete(item.Id);
+                item.EnqueueDelete();
+                deletedItems.Add(item);
+                items.Remove(item.Id);
+            }
+
+            // Send Operation Result
+            SendAccountOperationResult(AccountOperation.TakeItem, AccountOperationResult.Ok);
+
+            // Claim Items
+            item.ClaimItems(session);
+        }
+
+        private bool IsOnCooldown(uint cooldownGroupId)
+        {
+            if (!cooldowns.TryGetValue(cooldownGroupId, out AccountItemCooldown cooldown))
+                throw new ArgumentOutOfRangeException(nameof(cooldownGroupId));
+
+            return cooldown.GetRemainingDuration() > 0;
+        }
+
+        private void SetCooldown(uint cooldownGroupId)
+        {
+            if (!cooldowns.TryGetValue(cooldownGroupId, out AccountItemCooldown cooldown))
+                throw new ArgumentOutOfRangeException(nameof(cooldownGroupId));
+
+            uint duration = 0;
+            switch (cooldownGroupId)
+            {
+                case 1:
+                    duration = 1800;
+                    break;
+                case 2:
+                    duration = 1800;
+                    break;
+                case 3:
+                    duration = 28800;
+                    break;
+            }
+
+            cooldown.TriggerWithDuration(duration);
+            SendAccountItemCooldowns();
+        }
+
+        /// <summary>
+        /// Sends initial packets to the <see cref="WorldSession"/>.
+        /// </summary>
+        public void SendCharacterListPackets()
+        {
+            SendAccountItemList();
+            SendAccountItemCooldowns();
+        }
+
+        private void SendAccountItemList()
+        {
+            ServerAccountItems accountItems = new ServerAccountItems();
+
+            foreach (AccountItem item in items.Values)
+                accountItems.AccountItems.Add(item.BuildNetworkModel());
+
+            session.EnqueueMessageEncrypted(accountItems);
+        }
+
+        private void SendAccountItemDelete(ulong id)
+        {
+            session.EnqueueMessageEncrypted(new ServerAccountItemDelete
+            {
+                UserInventoryId = id
+            });
+        }
+
+        private void SendAccountOperationResult(AccountOperation operation, AccountOperationResult result)
+        {
+            session.EnqueueMessageEncrypted(new ServerAccountOperationResult
+            {
+                Operation = operation,
+                Result = result
+            });
+        }
+
+        private void SendAccountItemCooldowns()
+        {
+            foreach (AccountItemCooldown cooldown in cooldowns.Values)
+            {
+                if (cooldown.GetRemainingDuration() == 0)
+                    continue;
+
+                session.EnqueueMessageEncrypted(cooldown.BuildNetworkModel());
+            }
+        }
+
+        public IEnumerator<AccountItem> GetEnumerator()
+        {
+            return items.Values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Account/AccountItem.cs
+++ b/Source/NexusForever.WorldServer/Game/Account/AccountItem.cs
@@ -1,0 +1,136 @@
+﻿using Microsoft.EntityFrameworkCore;
+using NexusForever.Database.Auth;
+using NexusForever.Database.Auth.Model;
+using NexusForever.Shared.GameTable;
+using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.Account.Static;
+using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Network;
+using NexusForever.WorldServer.Network.Message.Model.Shared;
+using System;
+using System.Collections.Generic;
+
+namespace NexusForever.WorldServer.Game.Account
+{
+    public class AccountItem : ISaveAuth
+    {
+        public uint AccountId { get; }
+        public ulong Id { get; }
+        public AccountItemEntry Entry { get; }
+        public AccountItemFlag Flags { get; }
+
+        private AccountItemSaveMask saveMask;
+
+        /// <summary>
+        /// Creates an <see cref="AccountItem"/> from a given database model.
+        /// </summary>
+        public AccountItem(AccountItemModel model)
+        {
+            AccountId = model.AccountId;
+            Id = model.Id;
+
+            Entry = GameTableManager.Instance.AccountItem.GetEntry(model.ItemId);
+            if (Entry == null)
+                throw new InvalidOperationException($"AccountItem Entry {model.ItemId} cannot be found.");
+
+            Flags = (AccountItemFlag)Entry.Flags;
+
+            saveMask |= AccountItemSaveMask.None;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="AccountItem"/> from a <see cref="AccountItemEntry"/>.
+        /// </summary>
+        public AccountItem(WorldSession session, AccountItemEntry entry)
+        {
+            AccountId = session.Account.Id;
+            Id = AssetManager.Instance.NextAccountItemId;
+            Entry = entry ?? throw new ArgumentNullException(nameof(entry));
+            Flags = (AccountItemFlag)entry.Flags;
+
+            saveMask |= AccountItemSaveMask.Create;
+        }
+
+        /// <summary>
+        /// Saves this <see cref="AccountItem"/> to the database.
+        /// </summary>
+        public void Save(AuthContext context)
+        {
+            if (saveMask == AccountItemSaveMask.None)
+                return;
+
+            if ((saveMask & AccountItemSaveMask.Create) != 0)
+            {
+                var model = new AccountItemModel
+                {
+                    Id = Id,
+                    AccountId = AccountId,
+                    ItemId = Entry.Id
+                };
+
+                context.Add(model);
+            }
+            else if ((saveMask & AccountItemSaveMask.Delete) != 0)
+            {
+                var model = new AccountItemModel
+                {
+                    Id = Id,
+                    AccountId = AccountId
+                };
+
+                context.Entry(model).State = EntityState.Deleted;
+            }
+
+            saveMask = AccountItemSaveMask.None;
+        }
+
+        /// <summary>
+        /// Queues this <see cref="AccountItem"/> for deletion.
+        /// </summary>
+        public void EnqueueDelete()
+        {
+            saveMask = (saveMask & AccountItemSaveMask.Create) != 0 ? AccountItemSaveMask.None : AccountItemSaveMask.Delete;
+        }
+
+        /// <summary>
+        /// Return a <see cref="AccountInventoryItem"/> that describes this <see cref="AccountItem"/> to be sent to the client.
+        /// </summary>
+        public AccountInventoryItem BuildNetworkModel()
+        {
+            return new AccountInventoryItem
+            {
+                Id     = Id,
+                ItemId = Entry.Id
+            };
+        }
+
+        /// <summary>
+        /// Sends all items as part of this <see cref="AccountItem"/> to the requesting <see cref="WorldSession"/>.
+        /// </summary>
+        public void ClaimItems(WorldSession session)
+        {
+            if (session.Account.Id != AccountId)
+                throw new ArgumentException(nameof(session));
+
+            if (Entry.Item2Id != 0u)
+            {
+                List<uint> attachmentList = new List<uint>();
+                for (int i = 0; i < Entry.EntitlementCount; i++)
+                    attachmentList.Add(Entry.Item2Id);
+
+                // Couple items have 0 for entitlementCount, though most have 1+.
+                if (attachmentList.Count == 0u)
+                    attachmentList.Add(Entry.Item2Id);
+
+                session.Player.MailManager.SendMail(26454, Mail.Static.DeliveryTime.Instant, 461265, 461266, attachmentList, automaticClaim: true);
+            }
+                
+
+            if (Entry.EntitlementId != 0u)
+                session.EntitlementManager.SetAccountEntitlement((EntitlementType)Entry.EntitlementId, (int)Entry.EntitlementCount);
+
+            if (Entry.AccountCurrencyEnum != 0u)
+                session.AccountCurrencyManager.CurrencyAddAmount((AccountCurrencyType)Entry.AccountCurrencyEnum, Entry.AccountCurrencyAmount);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Account/AccountItemCooldown.cs
+++ b/Source/NexusForever.WorldServer/Game/Account/AccountItemCooldown.cs
@@ -1,0 +1,124 @@
+﻿using Microsoft.EntityFrameworkCore.ChangeTracking;
+using NexusForever.Database.Auth;
+using NexusForever.Database.Auth.Model;
+using NexusForever.WorldServer.Game.Account.Static;
+using NexusForever.WorldServer.Network;
+using NexusForever.WorldServer.Network.Message.Model;
+using System;
+
+namespace NexusForever.WorldServer.Game.Account
+{
+    public class AccountItemCooldown : ISaveAuth
+    {
+        public uint Id { get; }
+        public uint CooldownGroupId { get; }
+        public DateTime? TimeUsed { get; set; }
+        public uint Duration { get; set; }
+
+        private AccountItemCooldownSaveMask saveMask;
+
+        /// <summary>
+        /// Create an <see cref="AccountItemCooldown"/> from a database model.
+        /// </summary>
+        public AccountItemCooldown(AccountItemCooldownModel model)
+        {
+            Id              = model.Id;
+            CooldownGroupId = model.CooldownGroupId;
+            TimeUsed        = model.Timestamp;
+            Duration        = model.Duration;
+
+            saveMask = AccountItemCooldownSaveMask.None;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="AccountItemCooldown"/> for a given ID.
+        /// </summary>
+        public AccountItemCooldown(WorldSession session, uint cooldownGroupId, uint duration = 0)
+        {
+            Id = session.Account.Id;
+            CooldownGroupId = cooldownGroupId;
+            Duration = duration;
+            if (Duration > 0)
+                TimeUsed = DateTime.UtcNow;
+
+            saveMask = AccountItemCooldownSaveMask.Create;
+        }
+
+        /// <summary>
+        /// Save this <see cref="AccountItemCooldown"/> to the database.
+        /// </summary>
+        public void Save(AuthContext context)
+        {
+            if (saveMask == AccountItemCooldownSaveMask.None)
+                return;
+
+            if ((saveMask & AccountItemCooldownSaveMask.Create) != 0)
+            {
+                var model = new AccountItemCooldownModel
+                {
+                    Id = Id,
+                    CooldownGroupId = CooldownGroupId,
+                    Timestamp = TimeUsed,
+                    Duration = Duration
+                };
+
+                context.Add(model);
+            } 
+            else
+            {
+                var model = new AccountItemCooldownModel
+                {
+                    Id = Id,
+                    CooldownGroupId = CooldownGroupId
+                };
+
+                EntityEntry<AccountItemCooldownModel> entity = context.Attach(model);
+
+                if ((saveMask & AccountItemCooldownSaveMask.Modify) != 0)
+                {
+                    model.Timestamp = TimeUsed;
+                    entity.Property(p => p.Timestamp).IsModified = true;
+
+                    model.Duration = Duration;
+                    entity.Property(p => p.Duration).IsModified = true;
+                }
+            }
+
+            saveMask = AccountItemCooldownSaveMask.None;
+        }
+
+        /// <summary>
+        /// Triggers this <see cref="AccountItemCooldown"/> to set with a given duration (in seconds).
+        /// </summary>>
+        public void TriggerWithDuration(uint duration)
+        {
+            Duration = duration;
+            TimeUsed = DateTime.UtcNow;
+
+            saveMask |= AccountItemCooldownSaveMask.Modify;
+        }
+
+        /// <summary>
+        /// Returns the remaining time in seconds before this <see cref="AccountItemCooldown"/> resets.
+        /// </summary>
+        public uint GetRemainingDuration()
+        {
+            if (TimeUsed == null)
+                return 0;
+
+            return (uint)DateTime.UtcNow.Subtract((DateTime)TimeUsed).TotalSeconds > Duration ? 0 : Duration - (uint)DateTime.UtcNow.Subtract((DateTime)TimeUsed).TotalSeconds;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="ServerAccountItemCooldownSet"/> to be sent to the client.
+        /// </summary>
+        public ServerAccountItemCooldownSet BuildNetworkModel()
+        {
+            return new ServerAccountItemCooldownSet
+            {
+                AccountItemCooldownGroup = CooldownGroupId,
+                CooldownInSeconds = GetRemainingDuration()
+            };
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Account/Static/AccountItemCooldownSaveMask.cs
+++ b/Source/NexusForever.WorldServer/Game/Account/Static/AccountItemCooldownSaveMask.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Account.Static
+{
+    [Flags]
+    public enum AccountItemCooldownSaveMask
+    {
+        None   = 0x0000,
+        Create = 0x0001,
+        Delete = 0x0002,
+        Modify = 0x0004
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Account/Static/AccountItemFlag.cs
+++ b/Source/NexusForever.WorldServer/Game/Account/Static/AccountItemFlag.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Account.Static
+{
+    [Flags]
+    public enum AccountItemFlag
+    {
+        None        = 0x0000,
+        MultiClaim  = 0x0002
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Account/Static/AccountItemSaveMask.cs
+++ b/Source/NexusForever.WorldServer/Game/Account/Static/AccountItemSaveMask.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Account.Static
+{
+    [Flags]
+    public enum AccountItemSaveMask
+    {
+        None   = 0x0000,
+        Create = 0x0001,
+        Delete = 0x0002
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Account/Static/AccountOperation.cs
+++ b/Source/NexusForever.WorldServer/Game/Account/Static/AccountOperation.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Account.Static
+{
+    public enum AccountOperation
+    {
+        MTXPurchase              = 0x0000,
+        ClaimPending             = 0x0001,
+        ReturnPending            = 0x0002,
+        TakeItem                 = 0x0003,
+        GiftItem                 = 0x0004,
+        RedeemCoupon             = 0x0005,
+        GetCREDDExchangeInfo     = 0x0006,
+        SellCREDD                = 0x0007,
+        BuyCREDD                 = 0x0008,
+        CancelCREDDOrder         = 0x0009,
+        ExpireCREDDOrder         = 0x000A,
+        SellCREDDComplete        = 0x000B,
+        BuyCREDDComplete         = 0x000C,
+        CREDDRedeem              = 0x000F,
+        RequestDailyLoginRewards = 0x0010,
+        RequestPremiumLockboxKey = 0x0011
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Account/Static/AccountOperationResult.cs
+++ b/Source/NexusForever.WorldServer/Game/Account/Static/AccountOperationResult.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Account.Static
+{
+    public enum AccountOperationResult
+    {
+        Ok                        = 0x0000,
+        GenericFail               = 0x0001,
+        DBError                   = 0x0002,
+        MTXError                  = 0x0003,
+        InvalidOffer              = 0x0004,
+        InvalidPrice              = 0x0005,
+        NotEnoughCurrency         = 0x0006,
+        NeedTransaction           = 0x0007,
+        InvalidAccountItem        = 0x0008,
+        InvalidPendingItem        = 0x0009,
+        InvalidInventoryItem      = 0x000A,
+        NoConnection              = 0x000B,
+        NoCharacter               = 0x000C,
+        AlreadyClaimed            = 0x000D,
+        MaxEntitlementCount       = 0x000E,
+        NoRegift                  = 0x000F,
+        NoGifting                 = 0x0010,
+        InvalidFriend             = 0x0011,
+        InvalidCoupon             = 0x0012,
+        CannotReturn              = 0x0013,
+        Prereq                    = 0x0014,
+        CREDDExchangeNotLoaded    = 0x0015,
+        NoCREDD                   = 0x0016,
+        NoMatchingOrder           = 0x0017,
+        InvalidCREDDOrder         = 0x0018,
+        Cooldown                  = 0x0019,
+        MissingEntitlement        = 0x001A,
+        AlreadyClaimedMultiRedeem = 0x001B,
+        PremiumOnly               = 0x001C
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/AssetManager.cs
+++ b/Source/NexusForever.WorldServer/Game/AssetManager.cs
@@ -30,9 +30,15 @@ namespace NexusForever.WorldServer.Game
         /// </summary>
         public ulong NextMailId => nextMailId++;
 
+        /// <summary>
+        /// Id to be assigned to the next created account item.
+        /// </summary>
+        public ulong NextAccountItemId => nextAccountItemId++;
+
         private ulong nextCharacterId;
         private ulong nextItemId;
         private ulong nextMailId;
+        private ulong nextAccountItemId;
 
         private ImmutableDictionary<uint, ImmutableList<CharacterCustomizationEntry>> characterCustomisations;
 
@@ -48,9 +54,10 @@ namespace NexusForever.WorldServer.Game
 
         public void Initialise()
         {
-            nextCharacterId = DatabaseManager.Instance.CharacterDatabase.GetNextCharacterId() + 1ul;
-            nextItemId      = DatabaseManager.Instance.CharacterDatabase.GetNextItemId() + 1ul;
-            nextMailId      = DatabaseManager.Instance.CharacterDatabase.GetNextMailId() + 1ul;
+            nextCharacterId   = DatabaseManager.Instance.CharacterDatabase.GetNextCharacterId() + 1ul;
+            nextItemId        = DatabaseManager.Instance.CharacterDatabase.GetNextItemId() + 1ul;
+            nextMailId        = DatabaseManager.Instance.CharacterDatabase.GetNextMailId() + 1ul;
+            nextAccountItemId = DatabaseManager.Instance.AuthDatabase.GetNextAccountItemId() + 1ul;
 
             CacheCharacterCustomisations();
             CacheInventoryEquipSlots();

--- a/Source/NexusForever.WorldServer/Game/Entity/EntitlementManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/EntitlementManager.cs
@@ -105,6 +105,8 @@ namespace NexusForever.WorldServer.Game.Entity
             if (entry == null)
                 throw new ArgumentException($"Invalid entitlement type {type}!");
 
+            // TODO: Add RewardProperties where necessary
+
             AccountEntitlement entitlement = SetEntitlement(accountEntitlements, entry, value,
                 () => new AccountEntitlement(session.Account.Id, entry, (uint)value));
 
@@ -127,6 +129,8 @@ namespace NexusForever.WorldServer.Game.Entity
             EntitlementEntry entry = GameTableManager.Instance.Entitlement.GetEntry((ulong)type);
             if (entry == null)
                 throw new ArgumentException($"Invalid entitlement type {type}!");
+
+            // TODO: Implement Entitlements going to RewardProperties where necessary
 
             CharacterEntitlement entitlement = SetEntitlement(characterEntitlements, entry, value,
                 () => new CharacterEntitlement(session.Player.CharacterId, entry, (uint)value));

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -252,6 +252,7 @@ namespace NexusForever.WorldServer.Game.Entity
             SpellManager.Update(lastTick);
             CostumeManager.Update(lastTick);
             QuestManager.Update(lastTick);
+            MailManager.Update(lastTick);
 
             saveTimer.Update(lastTick);
             if (saveTimer.HasElapsed)
@@ -787,6 +788,7 @@ namespace NexusForever.WorldServer.Game.Entity
             Session.GenericUnlockManager.Save(context);
             Session.AccountCurrencyManager.Save(context);
             Session.EntitlementManager.Save(context);
+            Session.AccountInventory.Save(context);
 
             CostumeManager.Save(context);
             KeybindingManager.Save(context);

--- a/Source/NexusForever.WorldServer/Game/Mail/MailItem.cs
+++ b/Source/NexusForever.WorldServer/Game/Mail/MailItem.cs
@@ -140,6 +140,7 @@ namespace NexusForever.WorldServer.Game.Mail
 
             DeliveryTime = parameters.DeliveryTime;
             CreateTime   = DateTime.Now;
+            Flags        = parameters.Flags;
 
             saveMask     = MailSaveMask.Create;
         }
@@ -149,13 +150,17 @@ namespace NexusForever.WorldServer.Game.Mail
         /// </summary>
         public void EnqueueDelete()
         {
-            saveMask = MailSaveMask.Delete;
+            saveMask |= MailSaveMask.Delete;
         }
 
         public void Save(CharacterContext context)
         {
             if (saveMask != MailSaveMask.None)
             {
+                // Should only occur when mail is sent by a Creature then claimed immediately.
+                if ((saveMask & MailSaveMask.Create) != 0 && PendingDelete)
+                    return;
+
                 if ((saveMask & MailSaveMask.Create) != 0)
                 {
                     context.Add(new CharacterMailModel
@@ -243,6 +248,14 @@ namespace NexusForever.WorldServer.Game.Mail
         public void MarkAsRead()
         {
             Flags |= MailFlag.IsRead;
+        }
+
+        /// <summary>
+        /// Mark this <see cref="MailItem"/> as saved to the player.
+        /// </summary>
+        public void MarkAsSaved()
+        {
+            Flags |= MailFlag.IsSaved;
         }
 
         /// <summary>

--- a/Source/NexusForever.WorldServer/Game/Mail/MailParameters.cs
+++ b/Source/NexusForever.WorldServer/Game/Mail/MailParameters.cs
@@ -15,5 +15,6 @@ namespace NexusForever.WorldServer.Game.Mail
         public ulong MoneyToGive { get; set; }
         public ulong CodAmount { get; set; }
         public DeliveryTime DeliveryTime { get; set; }
+        public MailFlag Flags { get; set; }
     }
 }

--- a/Source/NexusForever.WorldServer/Game/Mail/Static/MailFlag.cs
+++ b/Source/NexusForever.WorldServer/Game/Mail/Static/MailFlag.cs
@@ -8,11 +8,12 @@ namespace NexusForever.WorldServer.Game.Mail.Static
     [Flags]
     public enum MailFlag
     {
-        None          = 0x00,
-        IsRead        = 0x02,
-        IsSaved       = 0x04,
-        NotReturnable = 0x08,
-        NoExpiry      = 0x20,
-        IsGift        = 0x40
+        None           = 0x00,
+        IsRead         = 0x02,
+        IsSaved        = 0x04,
+        NotReturnable  = 0x08,
+        NoExpiry       = 0x20,
+        IsGift         = 0x40,
+        AutomaticClaim = 0x80
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/AccountHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/AccountHandler.cs
@@ -34,5 +34,11 @@ namespace NexusForever.WorldServer.Network.Message.Handler
             // 0x0987 - Store catalogue finalised message
             GlobalStorefrontManager.Instance.HandleCatalogRequest(session);
         }
+
+        [MessageHandler(GameMessageOpcode.ClientAccountItemBind)]
+        public static void HandleAccountItemBind(WorldSession session, ClientAccountItemBind accountItemBind)
+        {
+            session.AccountInventory.BindItem(accountItemBind.UserInventoryId);
+        }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
@@ -120,8 +120,7 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                 session.Characters.Clear();
                 session.Characters.AddRange(characters);
 
-                session.AccountCurrencyManager.SendCharacterListPacket();
-                session.GenericUnlockManager.SendUnlockList();
+                session.AccountInventory.SendCharacterListPackets();
 
                 session.EnqueueMessageEncrypted(new ServerAccountEntitlements
                 {
@@ -133,6 +132,9 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                         })
                         .ToList()
                 });
+
+                session.AccountCurrencyManager.SendCharacterListPacket();
+                session.GenericUnlockManager.SendUnlockList();
 
                 var serverCharacterList = new ServerCharacterList
                 {

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientAccountItemBind.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientAccountItemBind.cs
@@ -1,0 +1,17 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Network.Message.Model.Shared;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ClientAccountItemBind)]
+    public class ClientAccountItemBind : IReadable
+    {
+        public ulong UserInventoryId { get; private set; }
+
+        public void Read(GamePacketReader reader)
+        {
+            UserInventoryId  = reader.ReadULong();
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerAccountItemDelete.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerAccountItemDelete.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Entity.Static;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerAccountItemDelete)]
+    public class ServerAccountItemDelete : IWritable
+    {
+        public ulong UserInventoryId { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(UserInventoryId);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerAccountOperationResult.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerAccountOperationResult.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Network.Message.Model.Shared;
+using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Game.Account.Static;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerAccountOperationResult)]
+    public class ServerAccountOperationResult : IWritable
+    {
+        public AccountOperation Operation { get; set; }
+        public AccountOperationResult Result { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(Operation, 32u);
+            writer.Write(Result, 32u);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/Shared/AccountInventoryItem.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/Shared/AccountInventoryItem.cs
@@ -9,7 +9,7 @@ namespace NexusForever.WorldServer.Network.Message.Model.Shared
         public uint ItemId { get; set; }
         public byte Unknown0 { get; set; } // 5
         public bool Unknown1 { get; set; }
-        public TargetPlayerIdentity TargetPlayerIdentity { get; set; } = new TargetPlayerIdentity();
+        public TargetPlayerIdentity ClaimerIdentity { get; set; } = new TargetPlayerIdentity();
 
         public void Write(GamePacketWriter writer)
         {
@@ -17,7 +17,7 @@ namespace NexusForever.WorldServer.Network.Message.Model.Shared
             writer.Write(ItemId);
             writer.Write(Unknown0, 5u);
             writer.Write(Unknown1);
-            TargetPlayerIdentity.Write(writer);
+            ClaimerIdentity.Write(writer);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/WorldSession.cs
+++ b/Source/NexusForever.WorldServer/Network/WorldSession.cs
@@ -24,6 +24,7 @@ namespace NexusForever.WorldServer.Network
         public GenericUnlockManager GenericUnlockManager { get; set; }
         public AccountCurrencyManager AccountCurrencyManager { get; set; }
         public EntitlementManager EntitlementManager { get; set; }
+        public AccountInventory AccountInventory { get; set; }
 
         public override void OnAccept(Socket newSocket)
         {
@@ -66,6 +67,7 @@ namespace NexusForever.WorldServer.Network
             GenericUnlockManager   = new GenericUnlockManager(this, account);
             AccountCurrencyManager = new AccountCurrencyManager(this, account);
             EntitlementManager     = new EntitlementManager(this, account);
+            AccountInventory       = new AccountInventory(this, account);
         }
 
         public void SetEncryptionKey(byte[] sessionKey)


### PR DESCRIPTION
Note on MailManager updates: 
- Updated `EnqueueMail()` to only push to `pendingMail` Queue. All Mail should be processed by the Update method (which wasn't being called before) otherwise pendingMail won't get moved to availableMail and the Player won't get notified.
- `1000d` -> `1d` change on the `UpdateTimer`. `1000d` is 1000 seconds for the `UpdateTimer`, and the comment mentioned 1 second. So fixed the typo.
- For Creature Mail, I've made it so that it foregos waiting for `Save` to happen. Majority of these cases will end with the Mail being deleted before it's Saved anyways. Even if it isn't, `Save()` will still be called on the Mail that jumped ahead of Save and will be saved appropriately. This only happens when the Player's Account is sending a Mail to itself, it must be instantly delivered and must be from a Creature. This functionality is necessary for Store and Account Items to work properly and I think the solution is pretty elegant.
- `pendingMail` fix in `Update()`: Before, mail would stay in pendingMail for the lifetime of the Player Instance, even after being added to `availableMail`.