### PR TITLE
Entity/RewardProperties: Account Tier based Reward Properties. Retail-like.

### DIFF
--- a/Source/NexusForever.Shared/GameTable/GameTableManager.cs
+++ b/Source/NexusForever.Shared/GameTable/GameTableManager.cs
@@ -456,7 +456,10 @@ namespace NexusForever.Shared.GameTable
         public GameTable<ResourceConversionEntry> ResourceConversion { get; private set; }
         public GameTable<ResourceConversionGroupEntry> ResourceConversionGroup { get; private set; }
         public GameTable<RewardPropertyEntry> RewardProperty { get; private set; }
+
+        [GameData]
         public GameTable<RewardPropertyPremiumModifierEntry> RewardPropertyPremiumModifier { get; private set; }
+
         public GameTable<RewardRotationContentEntry> RewardRotationContent { get; private set; }
         public GameTable<RewardRotationEssenceEntry> RewardRotationEssence { get; private set; }
         public GameTable<RewardRotationItemEntry> RewardRotationItem { get; private set; }

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -283,6 +283,7 @@ namespace NexusForever.Shared.Network.Message
         ServerAccountItemCooldownSet    = 0x0974,
         ServerAccountItemAdd            = 0x0975,
         ServerAccountItemsPending       = 0x0979,
+        ServerAccountTier               = 0x097F,
         ServerGenericUnlockList         = 0x0981,
         ServerGenericUnlock             = 0x0982,
         ServerGenericUnlockResult       = 0x0985,

--- a/Source/NexusForever.WorldServer/Game/Entity/Player.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Player.cs
@@ -176,6 +176,8 @@ namespace NexusForever.WorldServer.Game.Entity
             TimePlayedTotal = model.TimePlayedTotal;
             TimePlayedLevel = model.TimePlayedLevel;
 
+            Session.EntitlementManager.OnNewCharacter(model);
+
             foreach (CharacterStatModel statModel in model.Stat)
                 stats.Add((Stat)statModel.Stat, new StatValue(statModel));
 
@@ -195,8 +197,6 @@ namespace NexusForever.WorldServer.Game.Entity
             AchievementManager      = new CharacterAchievementManager(this, model);
             SupplySatchelManager    = new SupplySatchelManager(this, model);
             XpManager               = new XpManager(this, model);
-
-            Session.EntitlementManager.OnNewCharacter(model);
 
             // temp
             Properties.Add(Property.BaseHealth, new PropertyValue(Property.BaseHealth, 200f, 800f));
@@ -381,39 +381,7 @@ namespace NexusForever.WorldServer.Game.Entity
             // TODO: Move to Unlocks/Rewards Handler. A lot of these are tied to Entitlements which display in the character sheet, but don't actually unlock anything without this packet.
             Session.EnqueueMessageEncrypted(new ServerRewardPropertySet
             {
-                Variables = new List<ServerRewardPropertySet.RewardProperty>
-                {
-                    new ServerRewardPropertySet.RewardProperty
-                    {
-                        Id    = RewardProperty.CostumeSlots,
-                        Type  = 1,
-                        Value = CostumeManager.CostumeCap
-                    },
-                    new ServerRewardPropertySet.RewardProperty
-                    {
-                        Id    = RewardProperty.ExtraDecorSlots,
-                        Type  = 1,
-                        Value = 2000
-                    },
-                    new ServerRewardPropertySet.RewardProperty
-                    {
-                        Id    = RewardProperty.Trading,
-                        Type  = 1,
-                        Value = 1
-                    },
-                    new ServerRewardPropertySet.RewardProperty
-                    {
-                        Id    = RewardProperty.TradeskillMatStackLimit,
-                        Type  = 1,
-                        Value = 100
-                    },
-                    new ServerRewardPropertySet.RewardProperty
-                    {
-                        Id    = RewardProperty.TradeskillMatTrading,
-                        Type  = 1,
-                        Value = 1
-                    }
-                }
+                Variables = Session.EntitlementManager.GetRewardPropertiesNetworkMessage()
             });
 
             CostumeManager.SendInitialPackets();

--- a/Source/NexusForever.WorldServer/Game/Entity/RewardProperty.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/RewardProperty.cs
@@ -1,0 +1,104 @@
+﻿using NexusForever.Shared.GameTable.Model;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Network;
+using NexusForever.WorldServer.Network.Message.Model;
+using System;
+using System.Collections.Generic;
+
+namespace NexusForever.WorldServer.Game.Entity
+{
+    public class RewardProperty : IBuildable<ServerRewardPropertySet.RewardProperty>
+    {
+        public RewardPropertyType Type { get; }
+        public uint Data { get; }
+        public float Value { get; private set; }
+
+        private byte dataType;
+
+        /// <summary>
+        /// Create a <see cref="RewardProperty"/> with the provided <see cref="RewardPropertyPremiumModifierEntry"/>
+        /// </summary>
+        public RewardProperty(RewardPropertyPremiumModifierEntry entry)
+        {
+            Type = (RewardPropertyType)entry.RewardPropertyId;
+            Data = entry.RewardPropertyData;
+            dataType = (byte)(entry.RewardPropertyData > 0 ? 0 : 1);
+        }
+
+        /// <summary>
+        /// Adds data from the provided <see cref="RewardPropertyPremiumModifierEntry"/> to this <see cref="RewardProperty"/>. Should only be used when loading in to world.
+        /// </summary>
+        public void AddValue(RewardPropertyPremiumModifierEntry entry, EntitlementManager manager)
+        {
+            if (entry.ModifierValueInt > 0)
+                Value += entry.ModifierValueInt;
+
+            if (entry.ModifierValueFloat > 0 && entry.EntitlementIdModifierCount == 0)
+            {
+                Value += entry.ModifierValueFloat;
+
+                if (dataType != 0u)
+                    dataType = 2;
+            }
+
+            if (entry.EntitlementIdModifierCount > 0)
+            {
+                Value += manager.GetAccountEntitlement((EntitlementType)entry.EntitlementIdModifierCount)?.Amount ?? 0u;
+                Value += manager.GetCharacterEntitlement((EntitlementType)entry.EntitlementIdModifierCount)?.Amount ?? 0u;
+
+                // TODO: If the RewardProperty value is higher on Load that the Entitlement. Should we set the Entitlement to match? This is only necessary for things like Bank Slots (4 for Signature, 2 for Basic), Auction Slots, and Commodity Slots. Do we know if you subscribed, then unsubscribed, that you would keep those Bank Slots? Did they get greyed out and unusable?
+            }
+        }
+
+        /// <summary>
+        /// Adds to the current Value of this <see cref="RewardProperty"/>. If the <see cref="Player"/> is in World, it will also update them with the changes.
+        /// </summary>
+        public void AddValue(float value, Player player)
+        {
+            Value += value;
+
+            if (player.IsLoading)
+                return;
+
+            SendUpdate(player.Session);
+        }
+
+        /// <summary>
+        /// Sets the Value of this <see cref="RewardProperty"/>. This will overwrite all existing values.
+        /// </summary>
+        /// <remarks>Good for setting weekly Omnibit Caps with configuration.</remarks>
+        public void SetValue(float amount)
+        {
+            Value = amount;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="ServerRewardPropertySet.RewardProperty"/> with the data from this <see cref="RewardProperty"/>.
+        /// </summary>
+        public ServerRewardPropertySet.RewardProperty Build()
+        {
+            return new ServerRewardPropertySet.RewardProperty
+            {
+                Id = Type,
+                Data = Data,
+                Type = dataType,
+                Value = Value,
+            };
+        }
+
+        /// <summary>
+        /// Sends <see cref="ServerRewardPropertySet"/> to the <see cref="WorldSession"/> with data from this <see cref="RewardProperty"/>.
+        /// </summary>
+        private void SendUpdate(WorldSession session)
+        {
+            session.EnqueueMessageEncrypted(new ServerRewardPropertySet
+            {
+                Variables = new List<ServerRewardPropertySet.RewardProperty>
+                {
+                    Build()
+                }
+            });
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Entity/Static/RewardPropertyType.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Static/RewardPropertyType.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Replication of the CodeEnumRewardProperty enum from the client. Gaps for missing numbers.
     /// </summary>
-    public enum RewardProperty
+    public enum RewardPropertyType
     {
         XP                          = 1,
         CurrencyType                = 2,

--- a/Source/NexusForever.WorldServer/Game/Entity/SupplySatchelManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/SupplySatchelManager.cs
@@ -13,7 +13,7 @@ namespace NexusForever.WorldServer.Game.Entity
     public class SupplySatchelManager: IEnumerable<TradeskillMaterial>, ISaveCharacter
     {
         private readonly Player player;
-        private readonly uint maximumStackAmount;
+        private readonly uint maximumStackAmount = 100;
         private readonly Dictionary</* materialId */ushort, TradeskillMaterial> tradeskillMaterials = new Dictionary<ushort, TradeskillMaterial>();
 
         public SupplySatchelManager(Player owner, CharacterModel model)
@@ -21,7 +21,7 @@ namespace NexusForever.WorldServer.Game.Entity
             player = owner;
 
             // TODO: Make this configurable and powered by the same entry that would power the RewardProperty
-            maximumStackAmount = 100u;
+            maximumStackAmount = (uint)owner.Session.EntitlementManager.GetRewardProperty(Static.RewardPropertyType.TradeskillMatStackLimit, 0)?.Value;
 
             foreach (CharacterTradeskillMaterialModel tradeskillMaterial in model.TradeskillMaterials)
                 tradeskillMaterials.Add(tradeskillMaterial.MaterialId, new TradeskillMaterial(tradeskillMaterial));

--- a/Source/NexusForever.WorldServer/Game/Static/AccountTier.cs
+++ b/Source/NexusForever.WorldServer/Game/Static/AccountTier.cs
@@ -1,0 +1,8 @@
+﻿namespace NexusForever.WorldServer.Game.Static
+{
+    public enum AccountTier
+    {
+        Basic,
+        Signature
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Static/PremiumSystem.cs
+++ b/Source/NexusForever.WorldServer/Game/Static/PremiumSystem.cs
@@ -1,0 +1,9 @@
+﻿namespace NexusForever.WorldServer.Game.Static
+{
+    public enum PremiumSystem
+    {
+        None,
+        Hybrid,
+        VIP
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/CharacterHandler.cs
@@ -133,6 +133,10 @@ namespace NexusForever.WorldServer.Network.Message.Handler
                         })
                         .ToList()
                 });
+                session.EnqueueMessageEncrypted(new ServerAccountTier
+                {
+                    Tier = session.AccountTier
+                });
 
                 var serverCharacterList = new ServerCharacterList
                 {

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerAccountTier.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerAccountTier.cs
@@ -1,0 +1,17 @@
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Static;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerAccountTier)]
+    public class ServerAccountTier : IWritable
+    {
+        public AccountTier Tier { get; set; } // 5
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(Tier, 5u);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerRewardPropertySet.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerRewardPropertySet.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
-using RewardPropertyEnum = NexusForever.WorldServer.Game.Entity.Static.RewardProperty;
+using RewardPropertyEnum = NexusForever.WorldServer.Game.Entity.Static.RewardPropertyType;
 
 namespace NexusForever.WorldServer.Network.Message.Model
 {
@@ -10,14 +10,42 @@ namespace NexusForever.WorldServer.Network.Message.Model
     {
         public class RewardProperty : IWritable
         {
+            public class UnknownStruct : IWritable
+            {
+                public byte Unknown0 { get; set; } // 4
+                public uint Unknown1 { get; set; }
+                public byte Type { get; set; }
+                public float Value { get; set; }
+
+                public void Write(GamePacketWriter writer)
+                {
+                    writer.Write(Unknown0, 4u);
+                    writer.Write(Unknown1);
+                    writer.Write(Type, 2u);
+
+                    switch (Type)
+                    {
+                        case 0:
+                        case 2:
+                            writer.Write(Value);
+                            break;
+                        case 1:
+                            writer.Write((uint)Value);
+                            break;
+                    }
+                }
+            }
+
             public RewardPropertyEnum Id { get; set; }
+            public uint Data { get; set; }
             public byte Type { get; set; }
             public float Value { get; set; }
+            public List<UnknownStruct> UnknownStructs { get; set; } = new List<UnknownStruct>();
 
             public void Write(GamePacketWriter writer)
             {
                 writer.Write(Id, 6u);
-                writer.Write(0u);
+                writer.Write(Data);
                 writer.Write(Type, 2u);
 
                 switch (Type)
@@ -31,7 +59,8 @@ namespace NexusForever.WorldServer.Network.Message.Model
                         break;
                 }
 
-                writer.Write((byte)0);
+                writer.Write(UnknownStructs.Count, 8u);
+                UnknownStructs.ForEach(u => u.Write(writer));
             }
         }
 

--- a/Source/NexusForever.WorldServer/Network/WorldSession.cs
+++ b/Source/NexusForever.WorldServer/Network/WorldSession.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Sockets;
 using NexusForever.Database.Auth.Model;
 using NexusForever.Database.Character.Model;
+using NexusForever.Shared.Configuration;
 using NexusForever.Shared.Cryptography;
 using NexusForever.Shared.Network;
 using NexusForever.Shared.Network.Message;
@@ -10,6 +11,7 @@ using NexusForever.Shared.Network.Message.Model;
 using NexusForever.Shared.Network.Packet;
 using NexusForever.WorldServer.Game.Account;
 using NexusForever.WorldServer.Game.Entity;
+using NexusForever.WorldServer.Game.Static;
 using NexusForever.WorldServer.Network.Message.Model;
 
 namespace NexusForever.WorldServer.Network
@@ -24,6 +26,9 @@ namespace NexusForever.WorldServer.Network
         public GenericUnlockManager GenericUnlockManager { get; set; }
         public AccountCurrencyManager AccountCurrencyManager { get; set; }
         public EntitlementManager EntitlementManager { get; set; }
+
+        // TODO: Add Account Tiers to the Database?
+        public AccountTier AccountTier = (AccountTier)ConfigurationManager<WorldServerConfiguration>.Instance.Config.DefaultAccountTier;
 
         public override void OnAccept(Socket newSocket)
         {

--- a/Source/NexusForever.WorldServer/WorldServer.example.json
+++ b/Source/NexusForever.WorldServer/WorldServer.example.json
@@ -34,5 +34,6 @@
     },
     "RealmId": 1,
     "LengthOfInGameDay": 12600,
-    "CrossFactionChat":  true
+    "CrossFactionChat": true,
+    "DefaultAccountTier":  0
 }

--- a/Source/NexusForever.WorldServer/WorldServerConfiguration.cs
+++ b/Source/NexusForever.WorldServer/WorldServerConfiguration.cs
@@ -22,5 +22,6 @@ namespace NexusForever.WorldServer
         public ushort RealmId { get; set; }
         public uint LengthOfInGameDay { get; set; }
         public bool CrossFactionChat { get; set; } = true;
+        public byte DefaultAccountTier { get; set; }
     }
 }


### PR DESCRIPTION
This provides the necessary functionality to send unlocks to the client based on their Account Tier. The Account Tier itself is unimportant for the purpose of this feature. My goal was to make sure that we were sending things like Guild/Circle functionality, Bag Slots, Bank Slots, Auction and Commodity Counts appropriately. The Game Tables have this data available in it, so I am using them to generate the necessary properties.
In addition, the EntitlementManager can now be used to update the Client immediately. When I "purchase" a Costume slot, it is immediately reflected in my Character Pane without relog/zone. 

This was necessary work to get Store Purchasing working. This PR, #272, #273, and #275, are all necessary for Store Purchases to work. Outside of the added functionality, with the Store Purchasing, the majority of "Account features" should be complete.