### PR TITLE
Loot/Core: LootManager implementation, LootBag use  - WIP

### DIFF
--- a/Source/NexusForever.Database.World/Migrations/20200503180510_LootTables.Designer.cs
+++ b/Source/NexusForever.Database.World/Migrations/20200503180510_LootTables.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NexusForever.Database.World;
 
 namespace NexusForever.Database.World.Migrations
 {
     [DbContext(typeof(WorldContext))]
-    partial class WorldContextModelSnapshot : ModelSnapshot
+    [Migration("20200503180510_LootTables")]
+    partial class LootTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Source/NexusForever.Database.World/Migrations/20200503180510_LootTables.cs
+++ b/Source/NexusForever.Database.World/Migrations/20200503180510_LootTables.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace NexusForever.Database.World.Migrations
+{
+    public partial class LootTables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "loot_group",
+                columns: table => new
+                {
+                    id = table.Column<ulong>(type: "bigint(20) unsigned", nullable: false, defaultValue: 0ul),
+                    parentId = table.Column<ulong>(type: "bigint(20) unsigned", nullable: true),
+                    probability = table.Column<float>(type: "float", nullable: false, defaultValue: 100f),
+                    minDrop = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    maxDrop = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    condition = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    comment = table.Column<string>(type: "varchar(200)", nullable: true, defaultValue: "")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_loot_group", x => x.id);
+                    table.ForeignKey(
+                        name: "FK__loot_group_parentId__loot_group_id",
+                        column: x => x.parentId,
+                        principalTable: "loot_group",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "item_loot",
+                columns: table => new
+                {
+                    id = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    lootGroupId = table.Column<ulong>(type: "bigint(20) unsigned", nullable: true),
+                    comment = table.Column<string>(type: "varchar(200)", nullable: true, defaultValue: "")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_item_loot_loot_group_lootGroupId",
+                        column: x => x.lootGroupId,
+                        principalTable: "loot_group",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "loot_item",
+                columns: table => new
+                {
+                    id = table.Column<ulong>(type: "bigint(20) unsigned", nullable: false, defaultValue: 0ul),
+                    type = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    staticId = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    probability = table.Column<float>(type: "float", nullable: false, defaultValue: 100f),
+                    minCount = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    maxCount = table.Column<uint>(type: "int(10) unsigned", nullable: false, defaultValue: 0u),
+                    comment = table.Column<string>(type: "varchar(200)", nullable: true, defaultValue: "")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => new { x.id, x.type, x.staticId });
+                    table.ForeignKey(
+                        name: "FK__loot_item_id__loot_group_id",
+                        column: x => x.id,
+                        principalTable: "loot_group",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_item_loot_lootGroupId",
+                table: "item_loot",
+                column: "lootGroupId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_loot_group_parentId",
+                table: "loot_group",
+                column: "parentId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "item_loot");
+
+            migrationBuilder.DropTable(
+                name: "loot_item");
+
+            migrationBuilder.DropTable(
+                name: "loot_group");
+        }
+    }
+}

--- a/Source/NexusForever.Database.World/Model/ItemLootModel.cs
+++ b/Source/NexusForever.Database.World/Model/ItemLootModel.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace NexusForever.Database.World.Model
+{
+    public class ItemLootModel
+    {
+        public uint Id { get; set; }
+        public ulong? LootGroupId { get; set; }
+        public string Comment { get; set; }
+
+        public LootGroupModel LootGroup { get; set; }
+    }
+}

--- a/Source/NexusForever.Database.World/Model/LootGroupModel.cs
+++ b/Source/NexusForever.Database.World/Model/LootGroupModel.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace NexusForever.Database.World.Model
+{
+    public class LootGroupModel
+    {
+        public ulong Id { get; set; }
+        public ulong? ParentId { get; set; }
+        public float Probability { get; set; }
+        public uint MinDrop { get; set; }
+        public uint MaxDrop { get; set; }
+        public uint Condition { get; set; }
+        public string Comment { get; set; }
+
+        public LootGroupModel Parent { get; set; }
+        public ICollection<LootGroupModel> ChildGroup { get; set; } = new HashSet<LootGroupModel>();
+        public ICollection<LootItemModel> Item { get; set; } = new HashSet<LootItemModel>();
+    }
+}

--- a/Source/NexusForever.Database.World/Model/LootItemModel.cs
+++ b/Source/NexusForever.Database.World/Model/LootItemModel.cs
@@ -1,0 +1,15 @@
+﻿namespace NexusForever.Database.World.Model
+{
+    public class LootItemModel
+    {
+        public ulong Id { get; set; }
+        public uint Type { get; set; }
+        public uint StaticId { get; set; }
+        public float Probability { get; set; }
+        public uint MinCount { get; set; }
+        public uint MaxCount { get; set; }
+        public string Comment { get; set; }
+
+        public LootGroupModel LootGroup { get; set; }
+    }
+}

--- a/Source/NexusForever.Database.World/WorldContext.cs
+++ b/Source/NexusForever.Database.World/WorldContext.cs
@@ -13,6 +13,9 @@ namespace NexusForever.Database.World
         public DbSet<EntityVendorModel> EntityVendor { get; set; }
         public DbSet<EntityVendorCategoryModel> EntityVendorCategory { get; set; }
         public DbSet<EntityVendorItemModel> EntityVendorItem { get; set; }
+        public DbSet<ItemLootModel> ItemLoot { get; set; }
+        public DbSet<LootGroupModel> LootGroup { get; set; }
+        public DbSet<LootItemModel> LootItem { get; set; }
         public DbSet<StoreCategoryModel> StoreCategory { get; set; }
         public DbSet<StoreOfferGroupModel> StoreOfferGroup { get; set; }
         public DbSet<StoreOfferGroupCategoryModel> StoreOfferGroupCategory { get; set; }
@@ -312,6 +315,123 @@ namespace NexusForever.Database.World
                     .WithMany(p => p.EntityVendorItem)
                     .HasForeignKey(d => d.Id)
                     .HasConstraintName("FK__entity_vendor_item_id__entity_id");
+            });
+
+            modelBuilder.Entity<LootGroupModel>(entity =>
+            {
+                entity.ToTable("loot_group");
+
+                entity.Property(e => e.Id)
+                    .HasColumnName("id")
+                    .HasColumnType("bigint(20) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.ParentId)
+                    .HasColumnName("parentId")
+                    .HasColumnType("bigint(20) unsigned")
+                    .HasDefaultValue(null);
+
+                entity.Property(e => e.Probability)
+                    .HasColumnName("probability")
+                    .HasColumnType("float")
+                    .HasDefaultValue(100);
+
+                entity.Property(e => e.MinDrop)
+                    .HasColumnName("minDrop")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.MaxDrop)
+                    .HasColumnName("maxDrop")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Condition)
+                    .HasColumnName("condition")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Comment)
+                    .HasColumnName("comment")
+                    .HasColumnType("varchar(200)")
+                    .HasDefaultValue("");
+
+                entity.HasOne(d => d.Parent)
+                    .WithMany(p => p.ChildGroup)
+                    .HasForeignKey(d => d.ParentId)
+                    .HasConstraintName("FK__loot_group_parentId__loot_group_id")
+                    .IsRequired(false);
+            });
+
+            modelBuilder.Entity<LootItemModel>(entity =>
+            {
+                entity.ToTable("loot_item");
+
+                entity.HasKey(e => new { e.Id, e.Type, e.StaticId })
+                    .HasName("PRIMARY");
+
+                entity.Property(e => e.Id)
+                    .HasColumnName("id")
+                    .HasColumnType("bigint(20) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Type)
+                    .HasColumnName("type")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.StaticId)
+                    .HasColumnName("staticId")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Probability)
+                    .HasColumnName("probability")
+                    .HasColumnType("float")
+                    .HasDefaultValue(100);
+
+                entity.Property(e => e.MinCount)
+                    .HasColumnName("minCount")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.MaxCount)
+                    .HasColumnName("maxCount")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Comment)
+                    .HasColumnName("comment")
+                    .HasColumnType("varchar(200)")
+                    .HasDefaultValue("");
+
+                entity.HasOne(d => d.LootGroup)
+                    .WithMany(e => e.Item)
+                    .HasForeignKey(d => d.Id)
+                    .HasConstraintName("FK__loot_item_id__loot_group_id");
+            });
+
+            modelBuilder.Entity<ItemLootModel>(entity =>
+            {
+                entity.ToTable("item_loot");
+
+                entity.HasKey(e => e.Id)
+                    .HasName("PRIMARY");
+
+                entity.Property(e => e.Id)
+                    .HasColumnName("id")
+                    .HasColumnType("int(10) unsigned")
+                    .HasDefaultValue(0);
+
+                entity.Property(e => e.Comment)
+                    .HasColumnName("comment")
+                    .HasColumnType("varchar(200)")
+                    .HasDefaultValue("");
+
+                entity.Property(e => e.LootGroupId)
+                    .HasColumnName("lootGroupId")
+                    .HasColumnType("bigint(20) unsigned")
+                    .HasDefaultValue(null);
             });
 
             modelBuilder.Entity<StoreCategoryModel>(entity =>

--- a/Source/NexusForever.Database.World/WorldDatabase.cs
+++ b/Source/NexusForever.Database.World/WorldDatabase.cs
@@ -99,5 +99,26 @@ namespace NexusForever.Database.World
                 .AsNoTracking()
                 .ToImmutableList();
         }
+
+        public ImmutableList<ItemLootModel> GetAllItemLootTables()
+        {
+            using var context = new WorldContext(config);
+            return context.ItemLoot
+                .Include(e => e.LootGroup)
+                    .ThenInclude(e => e.Item)
+                .AsNoTracking()
+                .ToImmutableList();
+        }
+
+        public ImmutableList<LootGroupModel> GetLootGroupChildren(ulong parentId)
+        {
+            using var context = new WorldContext(config);
+            return context.LootGroup.Where(i => i.ParentId == parentId)
+                .Include(e => e.ChildGroup)
+                    .ThenInclude(e => e.Item)
+                .Include(e => e.Item)
+                .AsNoTracking()
+                .ToImmutableList();
+        }
     }
 }

--- a/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
+++ b/Source/NexusForever.Shared/Network/Message/GameMessageOpcode.cs
@@ -221,6 +221,7 @@ namespace NexusForever.Shared.Network.Message
         ClientEntityInteract            = 0x07EA,
         ClientPetCustomisation          = 0x07ED,
         ClientSelectRealm               = 0x07DF,
+        ServerLootNotify                = 0x07F2,
         ServerSpellGo                   = 0x07F4,
         Server07F5                      = 0x07F5, // spell related
         Server07F6                      = 0x07F6, // spell related
@@ -252,6 +253,7 @@ namespace NexusForever.Shared.Network.Message
         ServerVehiclePassengerAdd       = 0x086F,
         ServerUnitEnteredCombat         = 0x089A,
         Server089B                      = 0x089B, // mount related
+        ServerLootGrant                 = 0x08A5,
         Server08B3                      = 0x08B3,
         ServerSetUnitPathType           = 0x08B8,
         ServerVehiclePassengerRemove    = 0x08C7,

--- a/Source/NexusForever.WorldServer/Game/Loot/GlobalLootManager.cs
+++ b/Source/NexusForever.WorldServer/Game/Loot/GlobalLootManager.cs
@@ -1,0 +1,266 @@
+﻿using NexusForever.Database.World.Model;
+using NexusForever.Shared;
+using NexusForever.Shared.Database;
+using NexusForever.Shared.Game;
+using NexusForever.Shared.GameTable;
+using NexusForever.Shared.GameTable.Model;
+using NexusForever.WorldServer.Game.Account.Static;
+using NexusForever.WorldServer.Game.Entity;
+using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Game.Loot.Static;
+using NexusForever.WorldServer.Network;
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Loot
+{
+    public class GlobalLootManager : Singleton<GlobalLootManager>, IUpdate
+    {
+        private static readonly ILogger log = LogManager.GetCurrentClassLogger();
+
+        private readonly Dictionary<uint, List<LootGroup>> creatureLoot = new Dictionary<uint, List<LootGroup>>();
+        private readonly Dictionary<uint, List<LootGroup>> itemLoot = new Dictionary<uint, List<LootGroup>>();
+
+        private readonly List<LootInstance> lootInstances = new List<LootInstance>();
+
+        /// <summary>
+        /// This ID is assigned to <see cref="LootItem"/> to be sent to the client.
+        /// </summary>
+        /// <remarks>This ID may've been unique per client when generating "solo" loot.</remarks>
+        public int NextLootId => lootId + 1 != 0u ? lootId++ : lootId += 2;
+        private int lootId = int.MinValue;
+
+        private UpdateTimer updateTimer = new UpdateTimer(1d);
+
+        public GlobalLootManager()
+        {
+        }
+
+        /// <summary>
+        /// Initialise this <see cref="GlobalLootManager"/> Instance.
+        /// </summary>
+        public void Initialise()
+        {
+            DateTime loadStarted = DateTime.Now;
+
+            foreach (ItemLootModel itemLootModel in DatabaseManager.Instance.WorldDatabase.GetAllItemLootTables())
+                BuildLoot(itemLootModel.Id, LootEntityType.Item, itemLootModel.LootGroup);
+
+            log.Info($"Loaded LootGroups for {itemLoot.Count} Item(s) and {0} Creature(s) in {(DateTime.Now - loadStarted).TotalMilliseconds}ms");
+        }
+
+        /// <summary>
+        /// Builds all <see cref="LootGroup"/> for the given <see cref="LootGroupModel"/>, based on <see cref="LootEntityType"/> and ID.
+        /// </summary>
+        private void BuildLoot(uint entityId, LootEntityType type, LootGroupModel lootGroupModel)
+        {
+            switch (type)
+            {
+                case LootEntityType.Creature:
+                    if (!creatureLoot.ContainsKey(entityId))
+                        creatureLoot.Add(entityId, new List<LootGroup>());
+
+                    creatureLoot[entityId].Add(new LootGroup(lootGroupModel));
+                    break;
+                case LootEntityType.Item:
+                    if (!itemLoot.ContainsKey(entityId))
+                        itemLoot.Add(entityId, new List<LootGroup>());
+
+                    itemLoot[entityId].Add(new LootGroup(lootGroupModel));
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Called on every server Update.
+        /// </summary>
+        public void Update(double lastTick)
+        {
+            updateTimer.Update(lastTick);
+
+            foreach (LootInstance lootInstance in lootInstances)
+                lootInstance.Update(lastTick);
+
+            if (updateTimer.HasElapsed)
+            {
+                RemoveExpiredLootInstances();
+
+                updateTimer.Reset();
+            }
+        }
+
+        /// <summary>
+        /// Removes all <see cref="LootInstance"/> that have now expired (either claimed or timed out).
+        /// </summary>
+        private void RemoveExpiredLootInstances()
+        {
+            foreach (LootInstance lootInstance in lootInstances.Where(i => i.HasExpired).ToList())
+                lootInstances.Remove(lootInstance);
+        }
+
+        /// <summary>
+        /// Generate a new <see cref="LootInstance"/> based on the <see cref="LootEntityType"/> and ID from the cached <see cref="LootGroup"/>.
+        /// </summary>
+        private LootInstance GenerateLootInstance(uint entityId, uint entityGuid, Dictionary<ulong, uint> looterIds, LooterType looterType, LootEntityType lootEntityType)
+        {
+            LootInstance lootInstance = new LootInstance(entityGuid, looterIds, looterType, lootEntityType);
+
+            switch (lootEntityType)
+            {
+                case LootEntityType.Creature:
+                    if (!creatureLoot.TryGetValue(entityId, out List<LootGroup> creatureLootGroups))
+                        return null;
+
+                    foreach (LootGroup lootGroup in creatureLootGroups)
+                        foreach ((LootItem item, uint count) in lootGroup.GenerateLootDrops())
+                            lootInstance.AddLootItem(item.StaticId, item.Type, count);
+
+                    break;
+                case LootEntityType.Item:
+                    if (!itemLoot.TryGetValue(entityId, out List<LootGroup> itemLootGroups))
+                        return null;
+
+                    foreach (LootGroup lootGroup in itemLootGroups)
+                        foreach ((LootItem item, uint count) in lootGroup.GenerateLootDrops())
+                            lootInstance.AddLootItem(item.StaticId, item.Type, count);
+
+                    break;
+            }
+
+            // TODO: Generate currency rewards extra?
+
+            // TODO: Generate account currency rewards extra?
+
+            return lootInstance;
+        }
+
+        /// <summary>
+        /// Drops loot for the <see cref="WorldSession"/> after the <see cref="WorldEntity"/> has been killed or destroyed.
+        /// </summary>
+        /// <remarks>This should mainly be used when a creature is killed by the Player.</remarks>
+        public void DropLoot(WorldSession looter, WorldEntity lootedEntity)
+        {
+            Creature2Entry entry = GameTableManager.Instance.Creature2.GetEntry(lootedEntity.CreatureId);
+            if (entry == null)
+                throw new InvalidOperationException($"Creature2 Entry {lootedEntity.CreatureId} not found.");
+
+            if (!creatureLoot.ContainsKey(entry.Id))
+                return;
+
+            // Build Dictionary of IDs for the Player. Need CharacterID in case player logs out and back in before loot expires.
+            Dictionary<ulong, uint> playerIds = new Dictionary<ulong, uint>();
+            if (looter.Player == null)
+                throw new InvalidOperationException($"Player not found on the WorldSession {looter.Account.Id}");
+            playerIds.Add(looter.Player.CharacterId, looter.Player.Guid);
+
+            LootInstance lootInstance = GenerateLootInstance(entry.Id, lootedEntity.Guid, playerIds, LooterType.Player, LootEntityType.Creature);
+            lootInstances.Add(lootInstance);
+
+            lootInstance.SendLootNotify(looter);
+        }
+
+        /// <summary>
+        /// Drops loot for the <see cref="WorldSession"/> after the <see cref="Item"/> has been consumed.
+        /// </summary>
+        /// <remarks>This should mainly be used when a Player opens a Loot bag in their inventory.</remarks>
+        public void DropLoot(WorldSession looter, Item lootedItem)
+        {
+            if (!itemLoot.ContainsKey(lootedItem.Entry.Id))
+                return;
+
+            // Build Dictionary of IDs for the Player. Need CharacterID in case player logs out and back in before loot expires.
+            Dictionary<ulong, uint> playerIds = new Dictionary<ulong, uint>();
+            if (looter.Player == null)
+                throw new InvalidOperationException($"Player not found on the WorldSession {looter.Account.Id}");
+            playerIds.Add(looter.Player.CharacterId, looter.Player.Guid);
+
+            LootInstance lootInstance = GenerateLootInstance(lootedItem.Entry.Id, looter.Player.Guid, playerIds, LooterType.Player, LootEntityType.Item);
+            lootInstances.Add(lootInstance);
+
+            // This baby's gonna blow!
+            lootInstance.Explosion = true;
+
+            lootInstance.SendLootNotify(looter);
+        }
+
+        /// <summary>
+        /// Drops loot for the Group after the <see cref="WorldEntity"/> has been killed or destroyed.
+        /// </summary>
+        /// <remarks>This should mainly be used when a creature is killed by a Group.</remarks>
+        public void DropLoot(uint groupId, WorldEntity lootedEntity)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Return a <see cref="LootInstanceItem"/> based on a given ID.
+        /// </summary>
+        private LootInstanceItem GetLootInstanceItem(int lootInstanceItemId)
+        {
+            foreach (LootInstance lootInstance in lootInstances)
+            {
+                if (!lootInstance.HasLootInstanceId(lootInstanceItemId))
+                    continue;
+
+                foreach (LootInstanceItem item in lootInstance)
+                    if (item.Id == lootInstanceItemId)
+                        return item;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Give <see cref="LootInstanceItem"/> to the <see cref="WorldSession"/> by a given ID. Should only be called by client handler.
+        /// </summary>
+        public void GiveLoot(WorldSession looter, int lootInstanceItemId)
+        {
+            LootInstanceItem lootInstanceItem = GetLootInstanceItem(lootInstanceItemId);
+            if (lootInstanceItem == null)
+                throw new ArgumentNullException(nameof(lootInstanceItemId));
+
+            lootInstanceItem.SetWinner(looter.Player.CharacterId, looter.Player.Guid);
+            lootInstanceItem.DeliverItem(looter);
+        }
+
+        /// <summary>
+        /// Generate and deliver a single <see cref="LootInstanceItem"/> to a <see cref="WorldSession"/>, with a given <see cref="Item2Entry"/> and count.
+        /// </summary>
+        public void GiveLoot(WorldSession looter, Item2Entry entry, uint count)
+        {
+            LootInstanceItem lootInstance = new LootInstanceItem(entry.Id, LootItemType.StaticItem, count);
+            lootInstance.DeliverItem(looter);
+        }
+
+        /// <summary>
+        /// Generate and deliver a single <see cref="LootInstanceItem"/> to a <see cref="WorldSession"/>, with a given <see cref="VirtualItemEntry"/> and count.
+        /// </summary>
+        public void GiveLoot(WorldSession looter, VirtualItemEntry entry, uint count)
+        {
+            LootInstanceItem lootInstance = new LootInstanceItem(entry.Id, LootItemType.VirtualItem, count);
+            lootInstance.DeliverItem(looter);
+        }
+
+        /// <summary>
+        /// Generate and deliver a single <see cref="LootInstanceItem"/> to a <see cref="WorldSession"/>, with a given <see cref="AccountCurrencyType"/> and count.
+        /// </summary>
+        public void GiveLoot(WorldSession looter, AccountCurrencyType accountCurrencyType, uint count)
+        {
+            LootInstanceItem lootInstance = new LootInstanceItem((uint)accountCurrencyType, LootItemType.AccountCurrency, count);
+            lootInstance.DeliverItem(looter);
+        }
+
+        /// <summary>
+        /// Generate and deliver a single <see cref="LootInstanceItem"/> to a <see cref="WorldSession"/>, with a given <see cref="CurrencyType"/> and count.
+        /// </summary>
+        public void GiveLoot(WorldSession looter, CurrencyType currencyType, uint count)
+        {
+            LootInstanceItem lootInstance = new LootInstanceItem((uint)currencyType, LootItemType.Cash, count);
+            lootInstance.DeliverItem(looter);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Loot/LootGroup.cs
+++ b/Source/NexusForever.WorldServer/Game/Loot/LootGroup.cs
@@ -1,0 +1,116 @@
+﻿using NexusForever.Database.World.Model;
+using NexusForever.Shared.Database;
+using NexusForever.WorldServer.Game.Loot.Static;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NexusForever.WorldServer.Game.Loot
+{
+    public class LootGroup
+    {
+        public ulong Id { get; }
+        public LootEntityType Type { get; }
+        public float Probability { get; }
+
+        private uint minDrop;
+        private uint maxDrop;
+        private uint condition;
+
+        private List<LootGroup> childLootGroups = new List<LootGroup>();
+        private List<LootItem> lootItems = new List<LootItem>();
+
+        public LootGroup(LootGroupModel lootGroupModel)
+        {
+            Id = lootGroupModel.Id;
+            Probability = lootGroupModel.Probability;
+            minDrop = lootGroupModel.MinDrop;
+            maxDrop = lootGroupModel.MaxDrop;
+            if (minDrop > maxDrop)
+                maxDrop = minDrop;
+            condition = lootGroupModel.Condition;
+
+            foreach (LootGroupModel childLootGroup in DatabaseManager.Instance.WorldDatabase.GetLootGroupChildren(Id))
+                childLootGroups.Add(new LootGroup(childLootGroup));
+
+            foreach (LootItemModel lootItemModel in lootGroupModel.Item)
+                lootItems.Add(new LootItem(lootItemModel));
+        }
+
+        /// <summary>
+        /// Check this <see cref="LootGroup"/> to get a random chance of it dropping.
+        /// </summary>
+        private bool WillDrop()
+        {
+            // TODO: Check Conditional
+
+            double chance = new Random().NextDouble() * 100d;
+            if (chance < Probability)
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Generate a randomised instance of <see cref="LootItem"/> and Count associated with this <see cref="LootGroup"/>, and all Child <see cref="LootGroup"/>.
+        /// </summary>
+        public Dictionary<LootItem, uint> GenerateLootDrops()
+        {
+            Dictionary<LootItem, uint> itemsDropped = new Dictionary<LootItem, uint>();
+
+            if (!WillDrop())
+                return itemsDropped;
+
+            itemsDropped = GenerateLootItems();
+
+            if (minDrop == 0u && maxDrop == 0u)
+                return itemsDropped;
+
+            int desiredDrop = new Random().Next((int)minDrop, (int)(maxDrop + 1));
+            
+            // If we don't have enough items, get some more.
+            while (itemsDropped.Count < minDrop)
+            {
+                foreach ((LootItem lootItem, uint count) in GenerateLootItems())
+                    itemsDropped.Add(lootItem, count);
+            }
+
+            // If there are too many items, throw some out until we have the desired amount.
+            if (itemsDropped.Count > desiredDrop)
+            {
+                Dictionary<LootItem, uint> newItemsDropped = new Dictionary<LootItem, uint>();
+                while (itemsDropped.Count > maxDrop)
+                {
+                    int index = new Random().Next(0, itemsDropped.Count);
+                    LootItem item = itemsDropped.Keys.ElementAt(index);
+                    uint count = itemsDropped.Values.ElementAt(index);
+
+                    newItemsDropped.Add(item, count);
+                    itemsDropped.Remove(item);
+                }
+
+                return newItemsDropped;
+            }
+
+            return itemsDropped;
+        }
+
+        /// <summary>
+        /// Generate a <see cref="Dictionary{TKey, TValue}"/> containing <see cref="LootItem"/> and Counts for this <see cref="LootGroup"/>.
+        /// </summary>
+        private Dictionary<LootItem, uint> GenerateLootItems()
+        {
+            Dictionary<LootItem, uint> itemsDropped = new Dictionary<LootItem, uint>();
+
+            foreach (LootGroup lootGroup in childLootGroups)
+                foreach ((LootItem childGroupItem, uint count) in lootGroup.GenerateLootDrops())
+                    itemsDropped.Add(childGroupItem, count);
+
+            foreach (LootItem lootItem in lootItems)
+                if (lootItem.GetDrop(out uint count))
+                    itemsDropped.Add(lootItem, count);
+
+            return itemsDropped;
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Loot/LootInstance.cs
+++ b/Source/NexusForever.WorldServer/Game/Loot/LootInstance.cs
@@ -1,0 +1,126 @@
+﻿using NexusForever.Shared.Game;
+using NexusForever.Shared;
+using NexusForever.WorldServer.Game.Loot.Static;
+using NexusForever.WorldServer.Network;
+using NexusForever.WorldServer.Network.Message.Model;
+using NetworkLootItem = NexusForever.WorldServer.Network.Message.Model.Shared.LootItem;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NexusForever.WorldServer.Game.Loot
+{
+    public class LootInstance : IEnumerable<LootInstanceItem>, IUpdate
+    {
+        public uint Guid { get; }
+        public LootEntityType LootEntityType { get; }
+        public LooterType LooterType { get; }
+        public bool Explosion { get; set; }
+
+        public bool HasExpired => expiryTimer.HasElapsed || lootItems.Values.FirstOrDefault(i => i.Delivered == false) == null;
+
+        private Dictionary</* characterId */ ulong, /* guid */ uint> looterGuids { get; } = new Dictionary<ulong, uint>();
+        private Dictionary</*uniqueId*/ int, LootInstanceItem> lootItems = new Dictionary<int, LootInstanceItem>();
+
+        private UpdateTimer expiryTimer = new UpdateTimer(1800d);
+
+        /// <summary>
+        /// Create a new <see cref="LootInstance"/>.
+        /// </summary>
+        public LootInstance(uint unitGuid, Dictionary<ulong, uint> looterIds, LooterType looterType, LootEntityType lootEntityType)
+        {
+            Guid = unitGuid;
+            LootEntityType = lootEntityType;
+            LooterType = looterType;
+
+            foreach ((ulong characterId, uint guid) in looterIds)
+                looterGuids.Add(characterId, guid);            
+        }
+
+        /// <summary>
+        /// Updates this <see cref="LootInstance"/> expiry timer.
+        /// </summary>
+        public void Update(double lastTick)
+        {
+            if (expiryTimer.HasElapsed)
+                return;
+
+            expiryTimer.Update(lastTick);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="LootInstanceItem"/> for this <see cref="LootInstance"/>.
+        /// </summary>
+        public void AddLootItem(uint staticId, LootItemType type, uint count)
+        {
+            LootInstanceItem item = new LootInstanceItem(staticId, type, count);
+            lootItems.Add(item.Id, item);
+
+            if (LootEntityType == LootEntityType.Item)
+                item.SetWinner(looterGuids.First().Key, looterGuids.First().Value);
+        }
+
+        /// <summary>
+        /// Delivers all <see cref="LootInstanceItem"/> rewards to the given winner. Should only be used when a Player opens a Loot Bag.
+        /// </summary>
+        private void DeliverAllItemsImmediately(WorldSession session)
+        {
+            foreach (LootInstanceItem item in lootItems.Values)
+                item.DeliverItem(session, false);
+        }
+
+        /// <summary>
+        /// Delivers any already won Items to the <see cref="WorldSession"/> and sends a <see cref="ServerLootNotify"/> packet.
+        /// </summary>
+        public void SendLootNotify(WorldSession session)
+        {
+            if (LootEntityType == LootEntityType.Item && LooterType == LooterType.Player)
+                DeliverAllItemsImmediately(session);
+
+            List<NetworkLootItem> networkLootItems = new List<NetworkLootItem>();
+
+            foreach (LootInstanceItem item in lootItems.Values)
+            {
+                if (item.Type == LootItemType.AccountCurrency)
+                {
+                    networkLootItems.AddRange(item.BuildForAccountCurrency());
+                    continue;
+                }
+                
+                NetworkLootItem networkLootItem = item.Build();
+                networkLootItem.CanLoot = looterGuids.Keys.Contains(session.Player.CharacterId);
+                networkLootItem.Granted = item.Delivered;
+                if (item.Delivered)
+                    networkLootItem.UniqueId = 0;
+
+                networkLootItems.Add(networkLootItem);
+            }
+
+            session.EnqueueMessageEncrypted(new ServerLootNotify
+            {
+                UnitId = Guid,
+                Explosion = Explosion,
+                LootItems = networkLootItems
+            });
+        }
+
+        /// <summary>
+        /// Returns true if this <see cref="LootInstance"/> has a <see cref="LootInstanceItem"/> with the given ID.
+        /// </summary>
+        public bool HasLootInstanceId(int lootInstanceId)
+        {
+            return lootItems.Keys.Contains(lootInstanceId);
+        }
+
+        public IEnumerator<LootInstanceItem> GetEnumerator()
+        {
+            return lootItems.Values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Loot/LootInstanceItem.cs
+++ b/Source/NexusForever.WorldServer/Game/Loot/LootInstanceItem.cs
@@ -1,0 +1,174 @@
+﻿using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Account.Static;
+using NexusForever.WorldServer.Game.Entity.Static;
+using NexusForever.WorldServer.Game.Loot.Static;
+using NexusForever.WorldServer.Network;
+using NexusForever.WorldServer.Network.Message.Model;
+using NetworkLootItem = NexusForever.WorldServer.Network.Message.Model.Shared.LootItem;
+using System;
+using System.Collections.Generic;
+using NLog;
+
+namespace NexusForever.WorldServer.Game.Loot
+{
+    public class LootInstanceItem : IBuildable<NetworkLootItem>
+    {
+        private static readonly ILogger log = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// Loot Item ID the client uses to determine the instance.
+        /// </summary>
+        public int Id { get; }
+
+        /// <summary>
+        /// Guid of the "looted" entity. This is the Player Guid if the LootItemType is Item.
+        /// </summary>
+        public uint Guid { get; }
+
+        public uint StaticId { get; }
+        public LootItemType Type { get; }
+        public uint Amount { get; private set; }
+
+        public uint WinnerGuid { get; private set; }
+        public ulong WinnerCharacterId { get; private set; }
+        public bool Delivered { get; private set; }
+
+        /// <summary>
+        /// Create a new <see cref="LootInstanceItem"/>.
+        /// </summary>
+        public LootInstanceItem(uint staticId, LootItemType type, uint count)
+        {
+            Id = GlobalLootManager.Instance.NextLootId;
+            StaticId = staticId;
+            Type = type;
+            Amount = count;
+
+            if (type == LootItemType.StaticItem)
+            {
+                // TODO: Generate Random Stats and store them if item can have stats
+            }
+        }
+
+        public void AddToAmount(uint amount)
+        {
+            Amount += amount;
+        }
+
+        /// <summary>
+        /// Sets the Winner for this <see cref="LootInstanceItem"/>.
+        /// </summary>
+        public void SetWinner(ulong characterId, uint guid)
+        {
+            WinnerGuid = guid;
+            WinnerCharacterId = characterId;
+        }
+
+        /// <summary>
+        /// Generates and delivers the <see cref="LootItemType"/> to the given <see cref="WorldSession"/>. If sendAsGrant is unspecified or true, this will also send the <see cref="ServerLootGrant"/> packet to the <see cref="WorldSession"/>.
+        /// </summary>
+        public void DeliverItem(WorldSession session, bool sendAsGrant = true)
+        {
+            if (session == null || session.Player == null)
+                throw new ArgumentNullException(nameof(session));
+
+            if (WinnerGuid == 0u || WinnerCharacterId == 0u)
+                throw new InvalidOperationException("Winner IDs must be set before delivering this loot item.");
+
+            if (session.Player.CharacterId != WinnerCharacterId)
+                throw new InvalidOperationException($"Winner CharacterID {WinnerCharacterId} does not match the provided WorldSession CharacterID {session.Player.CharacterId}.");
+
+            if (Delivered)
+                throw new InvalidOperationException($"Loot item has already been delivered to the Winner!");
+
+            switch (Type)
+            {
+                case LootItemType.AccountCurrency:
+                    session.AccountCurrencyManager.CurrencyAddAmount((AccountCurrencyType)StaticId, Amount);
+                    // TODO: Send as Notify
+                    break;
+                case LootItemType.Cash:
+                    session.Player.CurrencyManager.CurrencyAddAmount((CurrencyType)StaticId, Amount, isLoot: true);
+                    break;
+                case LootItemType.StaticItem:
+                    session.Player.Inventory.ItemCreate(StaticId, Amount, ItemUpdateReason.Loot);
+                    break;
+                default:
+                    log.Warn($"{Type} not supported as deliverable loot.");
+                    return;
+            }
+
+            Delivered = true;
+
+            if (sendAsGrant)
+                SendGrant(session);
+        }
+
+        /// <summary>
+        /// Sends a <see cref="ServerLootGrant"/> packet for this <see cref="LootInstanceItem"/> to the <see cref="WorldSession"/>.
+        /// </summary>
+        private void SendGrant(WorldSession session)
+        {
+            session.EnqueueMessageEncrypted(new ServerLootGrant
+            {
+                UnitId = Guid,
+                LooterId = WinnerGuid,
+                LootItem = Build()
+            });
+        }
+
+        /// <summary>
+        /// Builds this <see cref="LootInstanceItem"/> into a <see cref="NetworkLootItem"/> to be sent to a <see cref="WorldSession"/>.
+        /// </summary>
+        public NetworkLootItem Build()
+        {
+            return new NetworkLootItem
+            {
+                UniqueId = Id,
+                Type = Type,
+                StaticId = StaticId,
+                Amount = Amount,
+                RandomCircuitData = 0,
+                RandomGlyphData = 0,
+            };
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IEnumerable{T}"/> containing up to 50 <see cref="NetworkLootItem"/>. Should only be used when the <see cref="LootItemType"/> is an Account Currency.
+        /// </summary>
+        /// <remarks>This gives the Player a "loot shower" effect when they receive a reward of omnibits or other Account Currencies.</remarks>
+        public IEnumerable<NetworkLootItem> BuildForAccountCurrency()
+        {
+            List<NetworkLootItem> lootItems = new List<NetworkLootItem>();
+
+            uint remainder = Amount > 50 ? Amount % 50 : 0;
+            uint totalItems = Amount > 50 ? 50 : Amount;
+            for (int i = 0; i < totalItems; i++)
+            {
+                NetworkLootItem lootItem = new NetworkLootItem
+                {
+                    UniqueId = 0,
+                    Type = Type,
+                    StaticId = StaticId,
+                    Amount = Amount > 50 ? Amount % 50 : 1,
+                    CanLoot = true,
+                    Granted = true
+                };
+
+                if (i == 0 && remainder > 0)
+                    lootItem.Amount += remainder;
+
+                lootItems.Add(lootItem);
+            }
+
+            return lootItems;
+        }
+
+        /// <summary>
+        /// Send the <see cref="LootInstanceItem"/> to the Winner if they're offline via mail.
+        /// </summary>
+        public void DeliverItemOffline()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Loot/LootItem.cs
+++ b/Source/NexusForever.WorldServer/Game/Loot/LootItem.cs
@@ -1,0 +1,46 @@
+﻿using NexusForever.Database.World.Model;
+using NexusForever.WorldServer.Game.Loot.Static;
+using System;
+
+namespace NexusForever.WorldServer.Game.Loot
+{
+    public class LootItem
+    {
+        public LootItemType Type { get; }
+        public uint StaticId { get; }
+
+        private float probability;
+        private uint minCount;
+        private uint maxCount;
+
+        /// <summary>
+        /// Instatiate a <see cref="LootItem"/> with a database model.
+        /// </summary>
+        /// <param name="model"></param>
+        public LootItem(LootItemModel model)
+        {
+            Type = (LootItemType)model.Type;
+            StaticId = model.StaticId;
+            probability = model.Probability;
+            minCount = model.MinCount;
+            maxCount = model.MaxCount;
+        }
+
+        /// <summary>
+        /// Check this <see cref="LootItem"/> to get a random chance of it dropping.
+        /// </summary>
+        public bool GetDrop(out uint count)
+        {
+            count = 0u;
+
+            double chance = new Random().NextDouble() * 100d;
+            if (chance < probability)
+            {
+                count = (uint)new Random().Next((int)minCount, (int)(maxCount + 1));
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Loot/Static/LootEntityType.cs
+++ b/Source/NexusForever.WorldServer/Game/Loot/Static/LootEntityType.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Loot.Static
+{
+    public enum LootEntityType
+    {
+        Creature,
+        Item
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Loot/Static/LootItemType.cs
+++ b/Source/NexusForever.WorldServer/Game/Loot/Static/LootItemType.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Loot.Static
+{
+    public enum LootItemType
+    {
+        StaticItem       = 0,
+        AltTable         = 1,
+        Cash             = 2,
+        Spell            = 4,
+        CurrencyExchange = 5,
+        VirtualItem      = 6,
+        AdventureSpell   = 7,
+        AccountItem      = 8,
+        AccountCurrency  = 9
+    }
+}

--- a/Source/NexusForever.WorldServer/Game/Loot/Static/LooterType.cs
+++ b/Source/NexusForever.WorldServer/Game/Loot/Static/LooterType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NexusForever.WorldServer.Game.Loot.Static
+{
+    public enum LooterType
+    {
+        Player,
+        Group,
+        Raid,
+        Guild
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Handler/ItemHandler.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Handler/ItemHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using NexusForever.Shared.Game.Events;
 using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
@@ -7,6 +8,7 @@ using NexusForever.Shared.Network.Message;
 using NexusForever.WorldServer.Game.Entity;
 using NexusForever.WorldServer.Game.Entity.Static;
 using NexusForever.WorldServer.Game.Housing;
+using NexusForever.WorldServer.Game.Loot;
 using NexusForever.WorldServer.Game.Map;
 using NexusForever.WorldServer.Game.Prerequisite;
 using NexusForever.WorldServer.Game.Spell;
@@ -125,6 +127,23 @@ namespace NexusForever.WorldServer.Network.Message.Handler
         public static void HandleClientItemMoveFromSupplySatchel(WorldSession session, ClientItemMoveFromSupplySatchel request)
         {
             session.Player.SupplySatchelManager.MoveToInventory(request.MaterialId, request.Amount);
+        }
+
+        [MessageHandler(GameMessageOpcode.ClientItemUseLootBag)]
+        public static void HandleClientItemUseLootBag(WorldSession session, ClientItemUseLootBag useLootBag)
+        {
+            Item item = session.Player.Inventory.GetItem(useLootBag.ItemLocation);
+            if (item == null)
+                throw new ArgumentException($"Item missing at Inventory Location {useLootBag.ItemLocation.Location} and Index {useLootBag.ItemLocation.BagIndex}.");
+
+            if (useLootBag.Guid != item.Guid)
+                throw new InvalidOperationException($"Guid {useLootBag.Guid} received does not match the Item found at Inventory Location {useLootBag.ItemLocation.Location} and Index {useLootBag.ItemLocation.BagIndex}.");
+
+            if (item.Entry.Item2CategoryId != 138)
+                throw new NotImplementedException();
+
+            if (session.Player.Inventory.ItemUse(item))
+                GlobalLootManager.Instance.DropLoot(session, item);
         }
     }
 }

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ClientItemUseLootBag.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ClientItemUseLootBag.cs
@@ -1,0 +1,19 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Network.Message.Model.Shared;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ClientItemUseLootBag)]
+    public class ClientItemUseLootBag : IReadable
+    {
+        public ItemLocation ItemLocation { get; private set; } = new ItemLocation();
+        public ulong Guid { get; private set; }
+
+        public void Read(GamePacketReader reader)
+        {
+            ItemLocation.Read(reader);
+            Guid = reader.ReadULong();
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerLootGrant.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerLootGrant.cs
@@ -1,0 +1,21 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Network.Message.Model.Shared;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerLootGrant)]
+    public class ServerLootGrant : IWritable
+    {
+        public uint UnitId { get; set; }
+        public uint LooterId { get; set; }
+        public LootItem LootItem { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(UnitId);
+            writer.Write(LooterId);
+            LootItem.Write(writer);
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/ServerLootNotify.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/ServerLootNotify.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Network.Message.Model.Shared;
+
+namespace NexusForever.WorldServer.Network.Message.Model
+{
+    [Message(GameMessageOpcode.ServerLootNotify)]
+    public class ServerLootNotify : IWritable
+    {
+        public uint UnitId { get; set; }
+        public uint Unknown0 { get; set; }
+        public bool Explosion { get; set; }
+        public List<LootItem> LootItems { get; set; }
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(UnitId);
+            writer.Write(Unknown0);
+            writer.Write(Explosion);
+            writer.Write(LootItems.Count);
+            LootItems.ForEach(i => i.Write(writer));
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/Network/Message/Model/Shared/LootItem.cs
+++ b/Source/NexusForever.WorldServer/Network/Message/Model/Shared/LootItem.cs
@@ -1,0 +1,42 @@
+﻿using NexusForever.Shared.Network;
+using NexusForever.Shared.Network.Message;
+using NexusForever.WorldServer.Game.Loot.Static;
+using System.Collections.Generic;
+
+namespace NexusForever.WorldServer.Network.Message.Model.Shared
+{
+    public class LootItem : IWritable
+    {
+        public int UniqueId { get; set; }
+        public LootItemType Type { get; set; }
+        public uint StaticId { get; set; }
+        public uint Amount { get; set; }
+        public bool CanLoot { get; set; }
+        public bool NeedsRoll { get; set; }
+        public bool Explosion { get; set; }
+        public bool Granted { get; set; }
+        public uint RollTime { get; set; }
+        public ulong RandomCircuitData { get; set; }
+        public uint RandomGlyphData { get; set; }
+        public uint Unknown2 { get; set; }
+        public List<TargetPlayerIdentity> MasterList { get; set; } = new List<TargetPlayerIdentity>();
+
+        public void Write(GamePacketWriter writer)
+        {
+            writer.Write(UniqueId);
+            writer.Write(Type, 32u);
+            writer.Write(StaticId);
+            writer.Write(Amount);
+            writer.Write(CanLoot);
+            writer.Write(NeedsRoll);
+            writer.Write(Explosion);
+            writer.Write(Granted);
+            writer.Write(RollTime);
+            writer.Write(RandomCircuitData);
+            writer.Write(RandomGlyphData);
+            writer.Write(Unknown2);
+            writer.Write(MasterList.Count);
+            MasterList.ForEach(m => m.Write(writer));
+        }
+    }
+}

--- a/Source/NexusForever.WorldServer/WorldServer.cs
+++ b/Source/NexusForever.WorldServer/WorldServer.cs
@@ -25,6 +25,7 @@ using NexusForever.WorldServer.Game.Spell;
 using NexusForever.WorldServer.Game.Storefront;
 using NexusForever.WorldServer.Network;
 using NexusForever.WorldServer.Game.CharacterCache;
+using NexusForever.WorldServer.Game.Loot;
 
 namespace NexusForever.WorldServer
 {
@@ -72,6 +73,7 @@ namespace NexusForever.WorldServer
             GlobalStorefrontManager.Instance.Initialise();
 
             GlobalAchievementManager.Instance.Initialise();
+            GlobalLootManager.Instance.Initialise();
 
             RealmId = ConfigurationManager<WorldServerConfiguration>.Instance.Config.RealmId;
             ServerManager.Instance.Initialise(RealmId); 
@@ -87,6 +89,7 @@ namespace NexusForever.WorldServer
                 ResidenceManager.Instance.Update(lastTick);
                 BuybackManager.Instance.Update(lastTick);
                 GlobalQuestManager.Instance.Update(lastTick);
+                GlobalLootManager.Instance.Update(lastTick);
             });
 
             using (WorldServerEmbeddedWebServer.Initialise())


### PR DESCRIPTION
This is a WIP. I'm pushing to PR for Rawaho to review. I don't believe this is a standard implementation of a Loot System, so looking for some feedback based on conversations he and I have had.

I used the following SQL and the Item Bag of Omnibits (`84623`) to test with. The below is not reflective of Retail, but was used for me to test lootGroup Hierarchy and randomisation of the LootGroup elgibility.

```sql
INSERT INTO `loot_group` (`id`, `parentId`, `probability`, `minDrop`, `maxDrop`, `condition`, `comment`) VALUES (1, NULL, 100, 0, 0, 0, 'Omnibits - Small');
INSERT INTO `loot_group` (`id`, `parentId`, `probability`, `minDrop`, `maxDrop`, `condition`, `comment`) VALUES (2, 1, 50, 0, 0, 0, 'Omnibits - Medium');
INSERT INTO `loot_group` (`id`, `parentId`, `probability`, `minDrop`, `maxDrop`, `condition`, `comment`) VALUES (3, 2, 25, 0, 0, 0, 'Omnibits - Large');

INSERT INTO `loot_item` (`id`, `type`, `staticId`, `probability`, `minCount`, `maxCount`, `comment`) VALUES (1, 9, 6, 100, 5, 10, '');
INSERT INTO `loot_item` (`id`, `type`, `staticId`, `probability`, `minCount`, `maxCount`, `comment`) VALUES (2, 9, 6, 100, 10, 20, '');
INSERT INTO `loot_item` (`id`, `type`, `staticId`, `probability`, `minCount`, `maxCount`, `comment`) VALUES (3, 9, 6, 100, 25, 50, '');

INSERT INTO `item_loot` (`id`, `lootGroupId`, `comment`) VALUES (84623, 1, 'Bag of Omnibits');
```