### PR TITLE
Quests/Core: Checklist quests support

### DIFF
--- a/Source/NexusForever.WorldServer/Command/Handler/EntityCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/EntityCommandHandler.cs
@@ -63,7 +63,8 @@ namespace NexusForever.WorldServer.Command.Handler
         {
             var stringBuilder = new StringBuilder();
             stringBuilder.AppendLine("=============================");
-            stringBuilder.AppendLine($"{GetCreatureName(targetEntity, lang)} | UnitId: {targetEntity.Guid} | CreatureID: {targetEntity.CreatureId} | Type: {targetEntity.Type}");
+            stringBuilder.AppendLine($"{GetCreatureName(targetEntity, lang)} | UnitId: {targetEntity.Guid} | Type: {targetEntity.Type}");
+            stringBuilder.AppendLine($"CreatureID: {targetEntity.CreatureId} | QuestChecklistIdx: {targetEntity.QuestChecklistIdx}");
 
             return stringBuilder;
         }

--- a/Source/NexusForever.WorldServer/Command/Handler/QuestCommandHandler.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/QuestCommandHandler.cs
@@ -96,13 +96,39 @@ namespace NexusForever.WorldServer.Command.Handler
 
             context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillCreature, creatureId, quantity);
             context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillCreature2, creatureId, quantity);
-            foreach (uint targetGroupId in AssetManager.Instance.GetTargetGroupsForCreatureId(creatureId) ?? Enumerable.Empty<uint>())
-            {
-                context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroup, targetGroupId, quantity);
-                context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroups, targetGroupId, quantity);
-            }
+            context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroup, creatureId, quantity);
+            context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.KillTargetGroups, creatureId, quantity);
 
             await context.SendMessageAsync($"Success! You've killed {quantity} of Creature ID: {creatureId}");
+            return;
+        }
+
+        [SubCommandHandler("activate", "id, [quantity | checklistIdx] - Update all quest objectives that require a kill with the given creature ID.")]
+        public async Task QuestActivateCommandHandler(CommandContext context, string command, string[] parameters)
+        {
+            if (parameters.Length < 1)
+            {
+                await context.SendErrorAsync("You must specify a Creature ID to kill.");
+                return;
+            }
+
+            if (!uint.TryParse(parameters[0], out uint creatureId))
+            {
+                await context.SendErrorAsync("Unable to parse Creature ID. Ensure you've entered just digits and please try again.");
+                return;
+            }
+
+            uint quantity = 1;
+            if (parameters.Length == 2 && uint.TryParse(parameters[1], out uint quantityParse))
+                quantity = quantityParse;
+
+            context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateEntity, creatureId, quantity);
+            context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateEntity2, creatureId, quantity);
+            context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateTargetGroup, creatureId, quantity);
+            context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.ActivateTargetGroupChecklist, creatureId, quantity);
+            context.Session.Player.QuestManager.ObjectiveUpdate(QuestObjectiveType.SucceedCSI, creatureId, quantity);
+
+            await context.SendMessageAsync($"Success! You've activated {quantity} of Creature ID: {creatureId}");
             return;
         }
     }

--- a/Source/NexusForever.WorldServer/Game/Entity/NonPlayer.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/NonPlayer.cs
@@ -35,7 +35,7 @@ namespace NexusForever.WorldServer.Game.Entity
             return new NonPlayerEntityModel
             {
                 CreatureId = CreatureId,
-                QuestChecklistIdx = 0
+                QuestChecklistIdx = QuestChecklistIdx
             };
         }
 

--- a/Source/NexusForever.WorldServer/Game/Entity/Simple.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/Simple.cs
@@ -10,8 +10,6 @@ namespace NexusForever.WorldServer.Game.Entity
     [DatabaseEntity(EntityType.Simple)]
     public class Simple : UnitEntity
     {
-        public byte QuestChecklistIdx { get; private set; }
-
         public Simple()
             : base(EntityType.Simple)
         {

--- a/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
+++ b/Source/NexusForever.WorldServer/Game/Entity/WorldEntity.cs
@@ -27,6 +27,8 @@ namespace NexusForever.WorldServer.Game.Entity
         public Faction Faction1 { get; set; }
         public Faction Faction2 { get; set; }
 
+        public byte QuestChecklistIdx { get; set; }
+
         public ulong ActivePropId { get; private set; }
         public ushort WorldSocketId { get; private set; }
 
@@ -83,15 +85,16 @@ namespace NexusForever.WorldServer.Game.Entity
         /// </summary>
         public virtual void Initialise(EntityModel model)
         {
-            EntityId     = model.Id;
-            CreatureId   = model.Creature;
-            Rotation     = new Vector3(model.Rx, model.Ry, model.Rz);
-            DisplayInfo  = model.DisplayInfo;
-            OutfitInfo   = model.OutfitInfo;
-            Faction1     = (Faction)model.Faction1;
-            Faction2     = (Faction)model.Faction2;
-            ActivePropId = model.ActivePropId;
-            WorldSocketId = model.WorldSocketId;
+            EntityId          = model.Id;
+            CreatureId        = model.Creature;
+            Rotation          = new Vector3(model.Rx, model.Ry, model.Rz);
+            DisplayInfo       = model.DisplayInfo;
+            OutfitInfo        = model.OutfitInfo;
+            Faction1          = (Faction)model.Faction1;
+            Faction2          = (Faction)model.Faction2;
+            QuestChecklistIdx = model.QuestChecklistIdx;
+            ActivePropId      = model.ActivePropId;
+            WorldSocketId     = model.WorldSocketId;
 
             foreach (EntityStatModel statModel in model.EntityStat)
                 stats.Add((Stat)statModel.Stat, new StatValue(statModel));

--- a/Source/NexusForever.WorldServer/Game/Quest/QuestObjective.cs
+++ b/Source/NexusForever.WorldServer/Game/Quest/QuestObjective.cs
@@ -1,15 +1,21 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using NexusForever.Database.Character;
 using NexusForever.Database.Character.Model;
 using NexusForever.Shared;
+using NexusForever.Shared.GameTable;
 using NexusForever.Shared.GameTable.Model;
 using NexusForever.WorldServer.Game.Quest.Static;
+using NLog;
 
 namespace NexusForever.WorldServer.Game.Quest
 {
     public class QuestObjective : IUpdate
     {
+        private static readonly ILogger log = LogManager.GetCurrentClassLogger();
+
         public QuestInfo Info { get; }
 
         public QuestObjectiveType Type => (QuestObjectiveType)Entry.Type;
@@ -41,6 +47,8 @@ namespace NexusForever.WorldServer.Game.Quest
 
         private uint? timer;
 
+        private List<uint> targetIds = new List<uint>();
+
         private QuestObjectiveSaveMask saveMask;
 
         /// <summary>
@@ -53,6 +61,9 @@ namespace NexusForever.WorldServer.Game.Quest
             Index    = model.Index;
             progress = model.Progress;
             timer    = model.Timer;
+
+            if (IsChecklist() || UsesTargetGroups())
+                BuildTargets();
         }
 
         /// <summary>
@@ -69,7 +80,53 @@ namespace NexusForever.WorldServer.Game.Quest
                 // TODO
             }
 
+            if (IsChecklist() || UsesTargetGroups())
+                BuildTargets();
+
             saveMask = QuestObjectiveSaveMask.Create;
+        }
+
+        /// <summary>
+        /// Builds the target ID list for this <see cref="QuestObjective"/>.
+        /// </summary>
+        private void BuildTargets()
+        {
+            uint targetGroupId = Entry.Data > 0 ? Entry.Data : Entry.TargetGroupIdRewardPane;
+            if (targetGroupId == 0u)
+                throw new InvalidOperationException();
+
+            TargetGroupEntry targetGroup = GameTableManager.Instance.TargetGroup.GetEntry(targetGroupId);
+            if (targetGroup == null)
+                throw new InvalidOperationException();
+
+            AddToTargets(targetGroup);
+
+            if (targetIds.Count < Entry.Count)
+                for (int i = targetIds.Count - 1; i < Entry.Count; i++)
+                    targetIds.Add(targetIds[0]);
+        }
+
+        private void AddToTargets(TargetGroupEntry entry)
+        {
+            switch ((TargetGroupType)entry.Type)
+            {
+                case TargetGroupType.CreatureIdGroup:
+                    targetIds.AddRange(entry.DataEntries.Where(d => d != 0u));
+                    break;
+                case TargetGroupType.OtherTargetGroup:
+                    foreach (uint targetGroupId in entry.DataEntries.Where(d => d != 0u))
+                    {
+                        TargetGroupEntry targetGroup = GameTableManager.Instance.TargetGroup.GetEntry(targetGroupId);
+                        if (targetGroup == null)
+                            throw new InvalidOperationException();
+
+                        AddToTargets(targetGroup);
+                    }
+                    break;
+                default:
+                    log.Warn($"Unsupported TargetGroup Type: {(TargetGroupType)entry.Type}");
+                    break;
+            }
         }
 
         public void Save(CharacterContext context, ulong characterId)
@@ -130,16 +187,51 @@ namespace NexusForever.WorldServer.Game.Quest
         }
 
         /// <summary>
-        /// Return if the objective has been completed.
+        /// Return if this <see cref="QuestObjective"/> is a checklist type.
+        /// </summary>
+        public bool IsChecklist()
+        {
+            // TODO: Determine other Types that are also Checklists
+            return Type == QuestObjectiveType.ActivateTargetGroupChecklist;
+        }
+
+        /// <summary>
+        /// Return if this <see cref="QuestObjective"/> uses target group data to complete.
+        /// </summary>
+        public bool UsesTargetGroups()
+        {
+            return (Type == QuestObjectiveType.ActivateTargetGroup ||
+                Type == QuestObjectiveType.ActivateTargetGroupChecklist ||
+                Type == QuestObjectiveType.KillTargetGroup ||
+                Type == QuestObjectiveType.KillTargetGroups ||
+                Type == QuestObjectiveType.TalkToTargetGroup);
+        }
+
+        /// <summary>
+        /// Return if the <see cref="QuestObjective"/> has been completed.
         /// </summary>
         public bool IsComplete()
         {
             return progress >= GetMaxValue();
         }
 
+        /// <summary>
+        /// Return if the <see cref="QuestObjective"/> requires the given ID to complete.
+        /// </summary>
+        public bool IsTarget(uint id)
+        {
+            return (Entry.Data == id || targetIds.Contains(id));
+        }
+
         private uint GetMaxValue()
         {
-            return IsDynamic() ? 1000u : Entry.Count;
+            if (IsChecklist())
+                return (uint)(1 << (int)Entry.Count) - 1;
+
+            if (IsDynamic())
+                return 1000u;
+
+            return Entry.Count;
         }
 
         /// <summary>
@@ -147,7 +239,9 @@ namespace NexusForever.WorldServer.Game.Quest
         /// </summary>
         public void ObjectiveUpdate(uint update)
         {
-            if (IsDynamic())
+            if (IsChecklist())
+                update = (uint)(1 << (int)update);
+            else if (IsDynamic())
                 update = (uint)(((float)update / Entry.Count) * 1000f);
 
             Progress = Math.Min(progress + update, GetMaxValue());


### PR DESCRIPTION
For this to function properly, entities that are part of a Checklist Quest will need to have their database entries updated/re-dumped with the `QuestChecklistIdx` from a sniff included.

This is used in quests like the Housing Starting Quest (Exile: http://www.jabbithole.com/quests/housing-of-the-future-9160) where you have to interact with certain entities and they update the quest appropriately.