### PR TITLE
Fix for !character level 50

### DIFF
--- a/Source/NexusForever.WorldServer/Command/Handler/CharacterCommandCategory.cs
+++ b/Source/NexusForever.WorldServer/Command/Handler/CharacterCommandCategory.cs
@@ -29,7 +29,7 @@ namespace NexusForever.WorldServer.Command.Handler
             byte level)
         {
             Player target = context.GetTargetOrInvoker<Player>();
-            if (level <= target.Level || level >= 50)
+            if (level <= target.Level || level > 50)
             {
                 context.SendMessage("Level must be greater than your current level and less than max level.");
                 return;


### PR DESCRIPTION
if you attempted to set your character level to 50. 50 == 50 so it was rejected.