### PR TITLE
Housing PlotIndex support - addresses #218 in the develop branch

### DIFF
--- a/Source/NexusForever.Shared/GameTable/GameTableManager.cs
+++ b/Source/NexusForever.Shared/GameTable/GameTableManager.cs
@@ -633,6 +633,7 @@ namespace NexusForever.Shared.GameTable
         [GameData]
         public GameTable<WorldSkyEntry> WorldSky { get; private set; }
 
+        [GameData]
         public GameTable<WorldSocketEntry> WorldSocket { get; private set; }
         public GameTable<WorldWaterEnvironmentEntry> WorldWaterEnvironment { get; private set; }
         public GameTable<WorldWaterFogEntry> WorldWaterFog { get; private set; }

--- a/Source/NexusForever.WorldServer/Game/Housing/Decor.cs
+++ b/Source/NexusForever.WorldServer/Game/Housing/Decor.cs
@@ -244,12 +244,13 @@ namespace NexusForever.WorldServer.Game.Housing
         /// <summary>
         /// Move <see cref="Decor"/> to supplied position.
         /// </summary>
-        public void Move(DecorType type, Vector3 position, Quaternion rotation, float scale)
+        public void Move(DecorType type, Vector3 position, Quaternion rotation, float scale, uint plotIndex)
         {
-            Type     = type;
-            Position = position;
-            Rotation = rotation;
-            Scale    = scale;
+            Type      = type;
+            Position  = position;
+            Rotation  = rotation;
+            Scale     = scale;
+            PlotIndex = plotIndex;
         }
 
         /// <summary>
@@ -257,7 +258,7 @@ namespace NexusForever.WorldServer.Game.Housing
         /// </summary>
         public void Crate()
         {
-            Move(DecorType.Crate, Vector3.Zero, Quaternion.Identity, 0f);
+            Move(DecorType.Crate, Vector3.Zero, Quaternion.Identity, 0f, int.MaxValue);
             DecorParentId = 0u;
         }
     }

--- a/Source/NexusForever.WorldServer/Game/Map/ResidenceMap.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/ResidenceMap.cs
@@ -292,7 +292,7 @@ namespace NexusForever.WorldServer.Game.Map
                 if (update.Scale < 0f)
                     throw new InvalidPacketValueException();
 
-                // new decor is being placed directly in the worldz
+                // new decor is being placed directly in the world
                 decor.Position = update.Position;
                 decor.Rotation = update.Rotation;
                 decor.Scale    = update.Scale;

--- a/Source/NexusForever.WorldServer/Game/Map/ResidenceMap.cs
+++ b/Source/NexusForever.WorldServer/Game/Map/ResidenceMap.cs
@@ -273,6 +273,7 @@ namespace NexusForever.WorldServer.Game.Map
 
             Decor decor = residence.DecorCreate(entry);
             decor.Type = update.DecorType;
+            decor.PlotIndex = update.PlotIndex;
 
             if (update.ColourShiftId != decor.ColourShiftId)
             {
@@ -291,7 +292,7 @@ namespace NexusForever.WorldServer.Game.Map
                 if (update.Scale < 0f)
                     throw new InvalidPacketValueException();
 
-                // new decor is being placed directly in the world
+                // new decor is being placed directly in the worldz
                 decor.Position = update.Position;
                 decor.Rotation = update.Rotation;
                 decor.Scale    = update.Scale;
@@ -361,7 +362,7 @@ namespace NexusForever.WorldServer.Game.Map
                     }
 
                     // crate->world
-                    decor.Move(update.DecorType, update.Position, update.Rotation, update.Scale);
+                    decor.Move(update.DecorType, update.Position, update.Rotation, update.Scale, update.PlotIndex);
                 }
                 else
                 {
@@ -370,7 +371,7 @@ namespace NexusForever.WorldServer.Game.Map
                     else
                     {
                         // world->world
-                        decor.Move(update.DecorType, update.Position, update.Rotation, update.Scale);
+                        decor.Move(update.DecorType, update.Position, update.Rotation, update.Scale, update.PlotIndex);
                         decor.DecorParentId = update.ParentDecorId;
                     }
                 }
@@ -444,7 +445,7 @@ namespace NexusForever.WorldServer.Game.Map
             WorldSocketEntry worldSocketEntry = GameTableManager.Instance.WorldSocket.GetEntry(residence.GetPlot((byte)update.PlotIndex).PlotEntry.WorldSocketId);
 
             // TODO: Calculate position based on individual maps on Community & Warplot residences
-            Vector3 worldPosition = new Vector3(1472f + update.Position.X, update.Position.Y, 1440f + update.Position.Z);
+            Vector3 worldPosition = new Vector3(1472f + update.Position.Z, -715f + update.Position.Y, 1440f - update.Position.X);
 
             (uint gridX, uint gridZ) = MapGrid.GetGridCoord(worldPosition);
             (uint localCellX, uint localCellZ) = MapCell.GetCellCoord(worldPosition);
@@ -457,7 +458,7 @@ namespace NexusForever.WorldServer.Game.Map
 
             log.Debug($"IsValidPlotForPosition - PlotIndex: {update.PlotIndex}, Range: {minBound}-{maxBound}, Coords: {globalCellX}, {globalCellZ}");
 
-            return !(globalCellX >= minBound && globalCellX <= maxBound && globalCellZ >= minBound && globalCellZ <= maxBound);
+            return (globalCellX >= minBound && globalCellX <= maxBound && globalCellZ >= minBound && globalCellZ <= maxBound);
         }
 
         /// <summary>


### PR DESCRIPTION
As mentioned in the commit message, the known issues are:
1) Currently requires the plotIndex database default to be set
to 0 in order to properly set the plotIndex when placing on PlotIndex=0
from the vendor.
2) When placing in PlotIndex=0, the Y value in the database is not what you
see in game. The position as placed in game does persist as expected across
server loads so long as the plotIndex in the database is properly set to 0
(see 1). If the plotIndex is set to Int.MaxValue instead of 0, the item will
raise from its intended location after a server restart.